### PR TITLE
add Software Breakpoints detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Please, if you encounter any of the anti-analysis tricks which you have seen in 
 
 # Anti-debugging attacks
 - IsDebuggerPresent
+- CheckRemoteDebuggerPresent
 - Process Environement Block (BeingDebugged)
 - Process Environement Block (NtGlobalFlag)
 - ProcessHeap (Flags)
@@ -18,9 +19,12 @@ Please, if you encounter any of the anti-analysis tricks which you have seen in 
 - NtQueryInformationProcess (ProcessDebugPort)
 - NtQueryInformationProcess (ProcessDebugFlags)
 - NtQueryInformationProcess (ProcessDebugObject)
+- NtSetInformationThread (HideThreadFromDebugger)
 - CloseHanlde (NtClose) Invalide Handle
 - UnhandledExceptionFilter
 - OutputDebugString (GetLastError())
-- NtSetInformationThread (HideThreadFromDebugger)
+- Hardware Breakpoints (SEH / GetThreadContext)
+- Software Breakpoints (INT3 / 0xCC)
+
 
 

--- a/al-khaser/Al-khaser.cpp
+++ b/al-khaser/Al-khaser.cpp
@@ -17,11 +17,12 @@ int main(void)
 	exec_check(&NtQueryInformationProcess_ProcessDebugPort, TEXT("Checking NtQueryInformationProcess with ProcessDebugPort "));
 	exec_check(&NtQueryInformationProcess_ProcessDebugFlags, TEXT("Checking NtQueryInformationProcess with ProcessDebugFlags "));
 	exec_check(&NtQueryInformationProcess_ProcessDebugObject, TEXT("Checking NtQueryInformationProcess with ProcessDebugObject "));
-	//exec_check(&NtSetInformationThread_ThreadHideFromDebugger, TEXT("Checking NtSetInformationThread with ThreadHideFromDebugger "));
-	//exec_check(&CloseHandle_InvalideHandle, TEXT("Checking CloseHandle with an invalide handle "));
-	//exec_check(&UnhandledExcepFilterTest, TEXT("Checking UnhandledExcepFilterTest "));
+	exec_check(&NtSetInformationThread_ThreadHideFromDebugger, TEXT("Checking NtSetInformationThread with ThreadHideFromDebugger "));
+	exec_check(&CloseHandle_InvalideHandle, TEXT("Checking CloseHandle with an invalide handle "));
+	exec_check(&UnhandledExcepFilterTest, TEXT("Checking UnhandledExcepFilterTest "));
 	exec_check(&OutputDebugStringAPI, TEXT("Checking OutputDebugString "));
 	exec_check(&HardwareBreakpoints, TEXT("Checking Hardware Breakpoints "));
+	exec_check(&SoftwareBreakpoints, TEXT("Checking Software Breakpoints "));
 
 	system("PAUSE");
 	return 0;

--- a/al-khaser/Anti Debug/HardwareBreakpoints.cpp
+++ b/al-khaser/Anti Debug/HardwareBreakpoints.cpp
@@ -34,14 +34,11 @@ BOOL HardwareBreakpoints_SEH ()
 	return IsDbgPresent;
 }
 
-
 BOOL HardwareBreakpoints_GetThreadContext ()
 {
-
 	// This structure is key to the function and is the 
 	// medium for detection and removal
-	PCONTEXT ctx;
-	ctx = PCONTEXT(VirtualAlloc(NULL, sizeof(ctx), MEM_COMMIT, PAGE_READWRITE));
+	PCONTEXT ctx = PCONTEXT(VirtualAlloc(NULL, sizeof(ctx), MEM_COMMIT, PAGE_READWRITE));
 	SecureZeroMemory(ctx, sizeof(CONTEXT));
 
 	// The CONTEXT structure is an in/out parameter therefore we have
@@ -62,6 +59,7 @@ BOOL HardwareBreakpoints_GetThreadContext ()
 
 BOOL HardwareBreakpoints()
 {
+	/* Check either by using GetThreadContext or SEH method */
 	if (HardwareBreakpoints_GetThreadContext() || HardwareBreakpoints_SEH())
 		return TRUE;
 	else

--- a/al-khaser/Anti Debug/SoftwareBreakpoints.cpp
+++ b/al-khaser/Anti Debug/SoftwareBreakpoints.cpp
@@ -1,0 +1,41 @@
+#include "SoftwareBreakpoints.h"
+
+/*
+Software breakpoints aka INT 3 represented in the IA-32 instruction set with the opcode CC (0xCC).
+Given a memory addresse and size, it is relatively simple to scan for the byte 0xCC -> if(pTmp[i] == 0xCC)
+An obfuscated method would be to check if our memory byte xored with 0x55 is equal 0x99 for example ... 
+*/
+
+VOID My_Critical_Function()
+{
+	/* Setting INT 3 BP here would be detected */
+	int a = 1;
+	int b = 2;
+	int c = a + b;
+	_tprintf(_T("I am critical function, you should protect against int3 bps %d"), c);
+}
+
+
+VOID Myfunction_Adresss_Next()
+{
+	/*
+	There is no guaranteed way of determining the size of a function at run time(and little reason to do so)
+	however if you assume that the linker located functions that are adjacent in the source code sequentially in memory,
+	then the following may give an indication of the size of a function Critical_Function by using :
+	int Critical_Function_length = (int)Myfunction_Adresss_Next - (int)Critical_Function
+	Works only if you compile the file in Release mode.
+	*/
+};
+
+BOOL SoftwareBreakpoints()
+{
+
+	size_t sSizeToCheck = (size_t)(Myfunction_Adresss_Next)-(size_t)(My_Critical_Function);
+	PUCHAR Critical_Function = (PUCHAR)My_Critical_Function;
+
+	for (size_t i = 0; i < sSizeToCheck; i++) {
+		if (Critical_Function[i] == 0xCC) // Adding another level of indirection : 0xCC xor 0x55 = 0x99
+			return TRUE;
+	}
+	return FALSE;
+}

--- a/al-khaser/Anti Debug/SoftwareBreakpoints.h
+++ b/al-khaser/Anti Debug/SoftwareBreakpoints.h
@@ -1,0 +1,7 @@
+#include <Windows.h>
+#include <stdio.h>
+#include <tchar.h>
+
+BOOL SoftwareBreakpoints();
+VOID Myfunction_Trap_Debugger();
+VOID Myfunction_Adresss_Next();

--- a/al-khaser/Shared/Common.cpp
+++ b/al-khaser/Shared/Common.cpp
@@ -9,7 +9,7 @@ VOID print_detected()
 	/* Get handle to standard output */
 	HANDLE nStdHandle = GetStdHandle(STD_OUTPUT_HANDLE);  
 	CONSOLE_SCREEN_BUFFER_INFO ConsoleScreenBufferInfo;
-	ZeroMemory(&ConsoleScreenBufferInfo, sizeof(CONSOLE_SCREEN_BUFFER_INFO));
+	SecureZeroMemory(&ConsoleScreenBufferInfo, sizeof(CONSOLE_SCREEN_BUFFER_INFO));
 
 	/* Save the original console color */
 	GetConsoleScreenBufferInfo(nStdHandle, &ConsoleScreenBufferInfo);
@@ -25,7 +25,7 @@ VOID print_not_detected()
 	/* Get handle to standard output */
 	HANDLE nStdHandle = GetStdHandle(STD_OUTPUT_HANDLE);  
 	CONSOLE_SCREEN_BUFFER_INFO ConsoleScreenBufferInfo;
-	ZeroMemory(&ConsoleScreenBufferInfo, sizeof(CONSOLE_SCREEN_BUFFER_INFO));
+	SecureZeroMemory(&ConsoleScreenBufferInfo, sizeof(CONSOLE_SCREEN_BUFFER_INFO));
 
 	/* Save the original console color */
 	GetConsoleScreenBufferInfo(nStdHandle, &ConsoleScreenBufferInfo);
@@ -41,7 +41,7 @@ VOID print_category(TCHAR* text)
 	/* Get handle to standard output */
 	HANDLE nStdHandle = GetStdHandle(STD_OUTPUT_HANDLE);  
 	CONSOLE_SCREEN_BUFFER_INFO ConsoleScreenBufferInfo;
-	ZeroMemory(&ConsoleScreenBufferInfo, sizeof(CONSOLE_SCREEN_BUFFER_INFO));
+	SecureZeroMemory(&ConsoleScreenBufferInfo, sizeof(CONSOLE_SCREEN_BUFFER_INFO));
 
 	/* Save the original console color */
 	GetConsoleScreenBufferInfo(nStdHandle, &ConsoleScreenBufferInfo);

--- a/al-khaser/Shared/Main.h
+++ b/al-khaser/Shared/Main.h
@@ -16,9 +16,7 @@
 #include "..\Anti Debug\UnhandledExceptionFilter_Handler.h"
 #include "..\Anti Debug\OutputDebugStringAPI.h"
 #include "..\Anti Debug\HardwareBreakpoints.h"
-
-
-
+#include "..\Anti Debug\SoftwareBreakpoints.h"
 
 
 

--- a/al-khaser/Shared/Utils.cpp
+++ b/al-khaser/Shared/Utils.cpp
@@ -7,7 +7,6 @@
 #include <Iphlpapi.h>
 #pragma comment(lib, "Iphlpapi.lib")
 #pragma comment(lib, "Shlwapi.lib")
-
 #include "Utils.h"
 
 
@@ -81,7 +80,6 @@ BOOL is_DirectoryExists(TCHAR* szPath)
 	return (dwAttrib != INVALID_FILE_ATTRIBUTES) && (dwAttrib & FILE_ATTRIBUTE_DIRECTORY);
 }
 
-
 BOOL check_mac_addr(TCHAR* szMac)
 {
 	BOOL bResult = FALSE;
@@ -136,8 +134,8 @@ BOOL GetOSDisplayString(LPTSTR pszOS)
 	BOOL bOsVersionInfoEx;
 	DWORD dwType;
 
-	ZeroMemory(&si, sizeof(SYSTEM_INFO));
-	ZeroMemory(&osvi, sizeof(OSVERSIONINFOEX));
+	SecureZeroMemory(&si, sizeof(SYSTEM_INFO));
+	SecureZeroMemory(&osvi, sizeof(OSVERSIONINFOEX));
 
 	osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
 	bOsVersionInfoEx = GetVersionEx((OSVERSIONINFO*)&osvi);
@@ -351,5 +349,3 @@ BOOL GetOSDisplayString(LPTSTR pszOS)
 		return FALSE;
 	}
 }
-
-

--- a/al-khaser/al-khaser.vcxproj
+++ b/al-khaser/al-khaser.vcxproj
@@ -170,6 +170,7 @@
     <ClCompile Include="Anti Debug\ProcessHeap_Flags.cpp" />
     <ClCompile Include="Anti Debug\ProcessHeap_ForceFlags.cpp" />
     <ClCompile Include="Anti Debug\ProcessHeap_NtGlobalFlag.cpp" />
+    <ClCompile Include="Anti Debug\SoftwareBreakpoints.cpp" />
     <ClCompile Include="Anti Debug\UnhandledExceptionFilter_Handler.cpp" />
     <ClCompile Include="Shared\Common.cpp" />
     <ClCompile Include="Shared\Utils.cpp" />
@@ -188,6 +189,7 @@
     <ClInclude Include="Anti Debug\ProcessHeap_Flags.h" />
     <ClInclude Include="Anti Debug\ProcessHeap_ForceFlags.h" />
     <ClInclude Include="Anti Debug\ProcessHeap_NtGlobalFlag.h" />
+    <ClInclude Include="Anti Debug\SoftwareBreakpoints.h" />
     <ClInclude Include="Anti Debug\UnhandledExceptionFilter_Handler.h" />
     <ClInclude Include="Shared\Common.h" />
     <ClInclude Include="Shared\Main.h" />

--- a/al-khaser/al-khaser.vcxproj.filters
+++ b/al-khaser/al-khaser.vcxproj.filters
@@ -75,6 +75,9 @@
     <ClCompile Include="Anti Debug\HardwareBreakpoints.cpp">
       <Filter>Anti Debug\Source</Filter>
     </ClCompile>
+    <ClCompile Include="Anti Debug\SoftwareBreakpoints.cpp">
+      <Filter>Anti Debug\Source</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Shared\VersionHelpers.h">
@@ -132,6 +135,9 @@
       <Filter>Anti Debug\Header</Filter>
     </ClInclude>
     <ClInclude Include="Anti Debug\HardwareBreakpoints.h">
+      <Filter>Anti Debug\Header</Filter>
+    </ClInclude>
+    <ClInclude Include="Anti Debug\SoftwareBreakpoints.h">
       <Filter>Anti Debug\Header</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
#include <Windows.h>
#include <stdio.h>


void Myfunction_Trap_Debugger()
{
	/* Setting INT 3 BP here would be detected */
	int a=1;
	int b=2;
	int c=a+b;
	printf ("I am the function that i'll trap your debugger, %d", c);
}

void Myfunction_Adresss_Next()
{ 
};

BOOL SoftwareBreakpoints(void* pMemory,  size_t SizeToCheck)
{
	/* Software breakpoints aka INT 3 represented in the IA-32 instruction set with the opcode CC (0xCC). 
	Given a memory addresse and size, it is relatively simple to scan for the byte 0xCC -> if(pTmp[i] == 0xCC)
	An obfuscated method would be to check if our memory byte xored with 0x55 is equal 0x99 for example ... */

    unsigned char *pTmp = (unsigned char*)pMemory;
    unsigned char tmpchar = 0;  

    for (size_t i = 0; i < SizeToCheck; i++)
	{
		tmpchar = pTmp[i];
        if( 0x99 == (tmpchar ^ 0x55) ) // Adding another level of indirection : 0xCC xor 0x55 = 0x99
			return TRUE;
	}    
	
	return FALSE;
}