### PR TITLE
Add two kernel debugger checks

### DIFF
--- a/al-khaser/Al-khaser.cpp
+++ b/al-khaser/Al-khaser.cpp
@@ -40,6 +40,7 @@ int main(void)
 	exec_check(&NtQueryObject_ObjectAllTypesInformation, TEXT("Checking NtQueryObject with ObjectAllTypesInformation : "));
 	exec_check(&NtYieldExecutionAPI, TEXT("Checking NtYieldExecution : "));
 	exec_check(&SetHandleInformatiom_ProtectedHandle, TEXT("Checking CloseHandle protected handle trick : "));
+	exec_check(&NtQuerySystemInformation_SystemKernelDebuggerInformation, TEXT("Checking NtQuerySystemInformation with SystemKernelDebuggerInformation : "));
 
 	/* Generic sandbox detection */
 	print_category(TEXT("Generic Sandboxe/VM Detection"));

--- a/al-khaser/Al-khaser.cpp
+++ b/al-khaser/Al-khaser.cpp
@@ -41,6 +41,7 @@ int main(void)
 	exec_check(&NtYieldExecutionAPI, TEXT("Checking NtYieldExecution : "));
 	exec_check(&SetHandleInformatiom_ProtectedHandle, TEXT("Checking CloseHandle protected handle trick : "));
 	exec_check(&NtQuerySystemInformation_SystemKernelDebuggerInformation, TEXT("Checking NtQuerySystemInformation with SystemKernelDebuggerInformation : "));
+	exec_check(&SharedUserData_KernelDebugger, TEXT("Checking SharedUserData->KdDebuggerEnabled : "));
 
 	/* Generic sandbox detection */
 	print_category(TEXT("Generic Sandboxe/VM Detection"));

--- a/al-khaser/Anti Debug/NtQuerySystemInformation_SystemKernelDebuggerInformation.cpp
+++ b/al-khaser/Anti Debug/NtQuerySystemInformation_SystemKernelDebuggerInformation.cpp
@@ -1,0 +1,38 @@
+#include "NtQuerySystemInformation_SystemKernelDebuggerInformation.h"
+
+/*
+When NtQuerySystemInformation is called with the SystemKernelDebuggerInformation class, the function will return
+a SYSTEM_KERNEL_DEBUGGER_INFORMATION struct which will reveal the presence of a kernel debugger.
+*/
+
+BOOL NtQuerySystemInformation_SystemKernelDebuggerInformation()
+{
+   	// Function pointer typedef for NtQuerySystemInformation
+	typedef NTSTATUS (WINAPI *pNtQuerySystemInformation)(IN UINT, OUT PVOID, IN ULONG, OUT PULONG);
+ 
+	// SystemKernelDebuggerInformation
+	const int SystemKernelDebuggerInformation = 0x23;
+
+	// The debugger information struct
+	SYSTEM_KERNEL_DEBUGGER_INFORMATION KdDebuggerInfo;
+
+	HMODULE hNtDll = LoadLibrary(_T("ntdll.dll"));
+	if(hNtDll == NULL)
+		DbgRaiseAssertionFailure();
+ 
+	// Get the function address
+	pNtQuerySystemInformation NtQuerySystemInfo = (pNtQuerySystemInformation)GetProcAddress(hNtDll, "NtQuerySystemInformation");
+	if(NtQuerySystemInfo == NULL)
+		DbgRaiseAssertionFailure();
+	
+	// Call NtQuerySystemInformation
+	NTSTATUS Status = NtQuerySystemInfo(SystemKernelDebuggerInformation, &KdDebuggerInfo, sizeof(SYSTEM_KERNEL_DEBUGGER_INFORMATION), NULL);
+	if (Status >= 0)
+	{
+		// KernelDebuggerEnabled almost always implies !KernelDebuggerNotPresent. KernelDebuggerNotPresent can sometimes
+		// change if the debugger is temporarily disconnected, but either of these means a debugger is enabled.
+		if (KdDebuggerInfo.KernelDebuggerEnabled || !KdDebuggerInfo.KernelDebuggerNotPresent)
+			return TRUE;
+	}
+	return FALSE;
+}

--- a/al-khaser/Anti Debug/NtQuerySystemInformation_SystemKernelDebuggerInformation.h
+++ b/al-khaser/Anti Debug/NtQuerySystemInformation_SystemKernelDebuggerInformation.h
@@ -1,0 +1,10 @@
+#include <Windows.h>
+#include <tchar.h>
+
+BOOL NtQuerySystemInformation_SystemKernelDebuggerInformation();
+
+typedef struct _SYSTEM_KERNEL_DEBUGGER_INFORMATION
+{
+	BOOLEAN KernelDebuggerEnabled;
+	BOOLEAN KernelDebuggerNotPresent;
+} SYSTEM_KERNEL_DEBUGGER_INFORMATION, *PSYSTEM_KERNEL_DEBUGGER_INFORMATION;

--- a/al-khaser/Anti Debug/SharedUserData_KernelDebugger.cpp
+++ b/al-khaser/Anti Debug/SharedUserData_KernelDebugger.cpp
@@ -1,0 +1,30 @@
+#include "SharedUserData_KernelDebugger.h"
+
+/*
+NtQuerySystemInformation can be used to detect the presence of a kernel debugger. However, the
+same information can be obtained from user mode with no system calls at all. This is done by
+reading from the KUSER_SHARED_DATA struct, which is has a fixed user mode address of 0x7FFE0000 in all versions
+of Windows in both 32 and 64 bit. In kernel mode it is located at 0xFFDF0000 (32 bit) or 0xFFFFF78000000000 (64 bit).
+Detailed information about KUSER_SHARED_DATA can be found here: http://www.geoffchappell.com/studies/windows/km/ntoskrnl/structs/kuser_shared_data.htm
+*/
+
+BOOL SharedUserData_KernelDebugger()
+{
+	// The fixed user mode address of KUSER_SHARED_DATA
+	const ULONG_PTR UserSharedData = 0x7FFE0000;
+
+	// UserSharedData->KdDebuggerEnabled is a BOOLEAN according to ntddk.h, which gives the false impression that it is
+	// either true or false. However, this field is actually a set of bit flags, and is only zero if no debugger is present.
+	const UCHAR KdDebuggerEnabledByte = *(UCHAR*)(UserSharedData + 0x2D4); // 0x2D4 = the offset of the field
+
+	// Extract the flags.
+	// The meaning of these is the same as in NtQuerySystemInformation(SystemKernelDebuggerInformation).
+	// Normally if a debugger is attached, KdDebuggerEnabled is true, KdDebuggerNotPresent is false and the byte is 0x3.
+	const BOOLEAN KdDebuggerEnabled = (KdDebuggerEnabledByte & 0x1) == 0x1;
+	const BOOLEAN KdDebuggerNotPresent = (KdDebuggerEnabledByte & 0x2) == 0;
+
+	if (KdDebuggerEnabled || !KdDebuggerNotPresent)
+		return TRUE;
+
+	return FALSE;
+}

--- a/al-khaser/Anti Debug/SharedUserData_KernelDebugger.h
+++ b/al-khaser/Anti Debug/SharedUserData_KernelDebugger.h
@@ -1,0 +1,3 @@
+#include <Windows.h>
+
+BOOL SharedUserData_KernelDebugger();

--- a/al-khaser/Shared/Main.h
+++ b/al-khaser/Shared/Main.h
@@ -26,6 +26,7 @@
 #include "..\Anti Debug\NtYieldExecution.h"
 #include "..\Anti Debug\SetHandleInformation_API.h"
 #include "..\Anti Debug\TLS_callbacks.h"
+#include "..\Anti Debug\NtQuerySystemInformation_SystemKernelDebuggerInformation.h"
 
 /* Anti dumping headers */
 #include "..\Anti Dump\ErasePEHeaderFromMemory.h"

--- a/al-khaser/Shared/Main.h
+++ b/al-khaser/Shared/Main.h
@@ -27,6 +27,7 @@
 #include "..\Anti Debug\SetHandleInformation_API.h"
 #include "..\Anti Debug\TLS_callbacks.h"
 #include "..\Anti Debug\NtQuerySystemInformation_SystemKernelDebuggerInformation.h"
+#include "..\Anti Debug\SharedUserData_KernelDebugger.h"
 
 /* Anti dumping headers */
 #include "..\Anti Dump\ErasePEHeaderFromMemory.h"

--- a/al-khaser/al-khaser.vcxproj
+++ b/al-khaser/al-khaser.vcxproj
@@ -185,6 +185,7 @@
     <ClCompile Include="Anti Debug\ProcessHeap_NtGlobalFlag.cpp" />
     <ClCompile Include="Anti Debug\SeDebugPrivilege.cpp" />
     <ClCompile Include="Anti Debug\SetHandleInformation_API.cpp" />
+    <ClCompile Include="Anti Debug\SharedUserData_KernelDebugger.cpp" />
     <ClCompile Include="Anti Debug\SoftwareBreakpoints.cpp" />
     <ClCompile Include="Anti Debug\TLS_callbacks.cpp" />
     <ClCompile Include="Anti Debug\UnhandledExceptionFilter_Handler.cpp" />
@@ -234,6 +235,7 @@
     <ClInclude Include="Anti Debug\ProcessHeap_NtGlobalFlag.h" />
     <ClInclude Include="Anti Debug\SeDebugPrivilege.h" />
     <ClInclude Include="Anti Debug\SetHandleInformation_API.h" />
+    <ClInclude Include="Anti Debug\SharedUserData_KernelDebugger.h" />
     <ClInclude Include="Anti Debug\SoftwareBreakpoints.h" />
     <ClInclude Include="Anti Debug\TLS_callbacks.h" />
     <ClInclude Include="Anti Debug\UnhandledExceptionFilter_Handler.h" />

--- a/al-khaser/al-khaser.vcxproj
+++ b/al-khaser/al-khaser.vcxproj
@@ -174,6 +174,7 @@
     <ClCompile Include="Anti Debug\NtQueryInformationProcess_ProcessDebugFlags.cpp" />
     <ClCompile Include="Anti Debug\NtQueryObject_AllTypesInformation.cpp" />
     <ClCompile Include="Anti Debug\NtQueryObject_ObjectTypeInformation.cpp" />
+    <ClCompile Include="Anti Debug\NtQuerySystemInformation_SystemKernelDebuggerInformation.cpp" />
     <ClCompile Include="Anti Debug\NtSetInformationThread_ThreadHideFromDebugger.cpp" />
     <ClCompile Include="Anti Debug\NtYieldExecution.cpp" />
     <ClCompile Include="Anti Debug\OutputDebugStringAPI.cpp" />
@@ -222,6 +223,7 @@
     <ClInclude Include="Anti Debug\NtQueryInformationProcess_ProcessDebugPort.h" />
     <ClInclude Include="Anti Debug\NtQueryInformationProcess_ProcessDebugFlags.h" />
     <ClInclude Include="Anti Debug\NtQueryObject_ObjectInformation.h" />
+    <ClInclude Include="Anti Debug\NtQuerySystemInformation_SystemKernelDebuggerInformation.h" />
     <ClInclude Include="Anti Debug\NtSetInformationThread_ThreadHideFromDebugger.h" />
     <ClInclude Include="Anti Debug\NtYieldExecution.h" />
     <ClInclude Include="Anti Debug\OutputDebugStringAPI.h" />

--- a/al-khaser/al-khaser.vcxproj.filters
+++ b/al-khaser/al-khaser.vcxproj.filters
@@ -222,6 +222,9 @@
     <ClCompile Include="Anti Debug\NtQuerySystemInformation_SystemKernelDebuggerInformation.cpp">
       <Filter>Anti Debug\Source</Filter>
     </ClCompile>
+    <ClCompile Include="Anti Debug\SharedUserData_KernelDebugger.cpp">
+      <Filter>Anti Debug\Source</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Shared\VersionHelpers.h">
@@ -372,6 +375,9 @@
       <Filter>Anti Debug\Header</Filter>
     </ClInclude>
     <ClInclude Include="Anti Debug\NtQuerySystemInformation_SystemKernelDebuggerInformation.h">
+      <Filter>Anti Debug\Header</Filter>
+    </ClInclude>
+    <ClInclude Include="Anti Debug\SharedUserData_KernelDebugger.h">
       <Filter>Anti Debug\Header</Filter>
     </ClInclude>
   </ItemGroup>

--- a/al-khaser/al-khaser.vcxproj.filters
+++ b/al-khaser/al-khaser.vcxproj.filters
@@ -219,6 +219,9 @@
     <ClCompile Include="Anti Debug\TLS_callbacks.cpp">
       <Filter>Anti Debug\Source</Filter>
     </ClCompile>
+    <ClCompile Include="Anti Debug\NtQuerySystemInformation_SystemKernelDebuggerInformation.cpp">
+      <Filter>Anti Debug\Source</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Shared\VersionHelpers.h">
@@ -366,6 +369,9 @@
       <Filter>Shared\Header</Filter>
     </ClInclude>
     <ClInclude Include="Anti Debug\TLS_callbacks.h">
+      <Filter>Anti Debug\Header</Filter>
+    </ClInclude>
+    <ClInclude Include="Anti Debug\NtQuerySystemInformation_SystemKernelDebuggerInformation.h">
       <Filter>Anti Debug\Header</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Hi, thanks for this great project! I've already found and fixed one bug in [ScyllaHide](https://github.com/x64dbg/ScyllaHide) thanks to it.

I noticed the anti-debug detection is very complete on the user mode side, but there is no detection of kernel debuggers. This can be interesting if you are running e.g. malware in a VM with a kernel debugger attached.

This PR adds two checks that essentially check the same thing (from the kernel's perspective), as explained in the comments. However they do this in different ways, the second of which is not very well known/widely used as far as I know, but is actually much harder to hide for the debugger.