### PR TITLE
Added process job anti-debug check.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,22 +18,22 @@
 
 ## Introduction
 
-al-khaser is a PoC malware with good intentions that aimes to stress your anti-malware system.
-It performs a bunch of nowadays malwares tricks and the goal is to see if you stay under the radar.
+al-khaser is a PoC "malware" application with good intentions that aims to stress your anti-malware system.
+It performs a bunch of common malware tricks with the goal of seeing if you stay under the radar.
 
 ![Logo](https://i.imgur.com/jEFhsJT.png)
 
 
 ## Download
 
-You can download the last release [here](https://github.com/LordNoteworthy/al-khaser/blob/master/al-khaser.exe?raw=true).
+You can download the latest release [here](https://github.com/LordNoteworthy/al-khaser/blob/master/al-khaser.exe?raw=true).
 
 
 ## Possible uses
 
 - You are making an anti-debug plugin and you want to check its effectiveness.
 - You want to ensure that your sandbox solution is hidden enough.
-- Or you want to ensure that your malware analysis environement is well hidden.
+- Or you want to ensure that your malware analysis environment is well hidden.
 
 Please, if you encounter any of the anti-analysis tricks which you have seen in a malware, don't hesitate to contribute.
 
@@ -65,6 +65,7 @@ Please, if you encounter any of the anti-analysis tricks which you have seen in 
 - SeDebugPrivilege (Csrss.exe)
 - NtYieldExecution / SwitchToThread
 - TLS callbacks
+- Process jobs
 
 ### Anti-Dumping
 - Erase PE header from memory
@@ -101,142 +102,142 @@ Please, if you encounter any of the anti-analysis tricks which you have seen in 
 
 ### Anti-Virtualization / Full-System Emulation
 - **Registry key value artifacts**
-	- HARDWARE\\DEVICEMAP\\Scsi\\Scsi Port 0\\Scsi Bus 0\\Target Id 0\\Logical Unit Id 0 (Identifier) (VBOX)
-	- HARDWARE\\DEVICEMAP\\Scsi\\Scsi Port 0\\Scsi Bus 0\\Target Id 0\\Logical Unit Id 0 (Identifier) (QEMU)
-	- HARDWARE\\Description\\System (SystemBiosVersion) (VBOX)
-	- HARDWARE\\Description\\System (SystemBiosVersion) (QEMU)
-	- HARDWARE\\Description\\System (VideoBiosVersion) (VIRTUALBOX)
-	- HARDWARE\\Description\\System (SystemBiosDate) (06/23/99)
-	- HARDWARE\\DEVICEMAP\\Scsi\\Scsi Port 0\\Scsi Bus 0\\Target Id 0\\Logical Unit Id 0 (Identifier) (VMWARE)
-	- HARDWARE\\DEVICEMAP\\Scsi\\Scsi Port 1\\Scsi Bus 0\\Target Id 0\\Logical Unit Id 0 (Identifier) (VMWARE)
-	- HARDWARE\\DEVICEMAP\\Scsi\\Scsi Port 2\\Scsi Bus 0\\Target Id 0\\Logical Unit Id 0 (Identifier) (VMWARE)
+  - HARDWARE\\DEVICEMAP\\Scsi\\Scsi Port 0\\Scsi Bus 0\\Target Id 0\\Logical Unit Id 0 (Identifier) (VBOX)
+  - HARDWARE\\DEVICEMAP\\Scsi\\Scsi Port 0\\Scsi Bus 0\\Target Id 0\\Logical Unit Id 0 (Identifier) (QEMU)
+  - HARDWARE\\Description\\System (SystemBiosVersion) (VBOX)
+  - HARDWARE\\Description\\System (SystemBiosVersion) (QEMU)
+  - HARDWARE\\Description\\System (VideoBiosVersion) (VIRTUALBOX)
+  - HARDWARE\\Description\\System (SystemBiosDate) (06/23/99)
+  - HARDWARE\\DEVICEMAP\\Scsi\\Scsi Port 0\\Scsi Bus 0\\Target Id 0\\Logical Unit Id 0 (Identifier) (VMWARE)
+  - HARDWARE\\DEVICEMAP\\Scsi\\Scsi Port 1\\Scsi Bus 0\\Target Id 0\\Logical Unit Id 0 (Identifier) (VMWARE)
+  - HARDWARE\\DEVICEMAP\\Scsi\\Scsi Port 2\\Scsi Bus 0\\Target Id 0\\Logical Unit Id 0 (Identifier) (VMWARE)
 
 - **Registry Keys artifacts**
-	- "HARDWARE\\ACPI\\DSDT\\VBOX__"
-	- "HARDWARE\\ACPI\\FADT\\VBOX__"
-	- "HARDWARE\\ACPI\\RSDT\\VBOX__"
-	- "SOFTWARE\\Oracle\\VirtualBox Guest Additions"
-	- "SYSTEM\\ControlSet001\\Services\\VBoxGuest"
-	- "SYSTEM\\ControlSet001\\Services\\VBoxMouse"
-	- "SYSTEM\\ControlSet001\\Services\\VBoxService"
-	- "SYSTEM\\ControlSet001\\Services\\VBoxSF"
-	- "SYSTEM\\ControlSet001\\Services\\VBoxVideo"
-	- SOFTWARE\\VMware, Inc.\\VMware Tools
-	- SOFTWARE\\Wine
+  - "HARDWARE\\ACPI\\DSDT\\VBOX__"
+  - "HARDWARE\\ACPI\\FADT\\VBOX__"
+  - "HARDWARE\\ACPI\\RSDT\\VBOX__"
+  - "SOFTWARE\\Oracle\\VirtualBox Guest Additions"
+  - "SYSTEM\\ControlSet001\\Services\\VBoxGuest"
+  - "SYSTEM\\ControlSet001\\Services\\VBoxMouse"
+  - "SYSTEM\\ControlSet001\\Services\\VBoxService"
+  - "SYSTEM\\ControlSet001\\Services\\VBoxSF"
+  - "SYSTEM\\ControlSet001\\Services\\VBoxVideo"
+  - SOFTWARE\\VMware, Inc.\\VMware Tools
+  - SOFTWARE\\Wine
 
 - **File system artifacts**
-	- "system32\\drivers\\VBoxMouse.sys"
-	- "system32\\drivers\\VBoxGuest.sys"
-	- "system32\\drivers\\VBoxSF.sys"
-	- "system32\\drivers\\VBoxVideo.sys"
-	- "system32\\vboxdisp.dll"
-	- "system32\\vboxhook.dll"
-	- "system32\\vboxmrxnp.dll"
-	- "system32\\vboxogl.dll"
-	- "system32\\vboxoglarrayspu.dll"
-	- "system32\\vboxoglcrutil.dll"
-	- "system32\\vboxoglerrorspu.dll"
-	- "system32\\vboxoglfeedbackspu.dll"
-	- "system32\\vboxoglpackspu.dll"
-	- "system32\\vboxoglpassthroughspu.dll"
-	- "system32\\vboxservice.exe"
-	- "system32\\vboxtray.exe"
-	- "system32\\VBoxControl.exe"
-	- "system32\\drivers\\vmmouse.sys"
-	- "system32\\drivers\\vmhgfs.sys"
+  - "system32\\drivers\\VBoxMouse.sys"
+  - "system32\\drivers\\VBoxGuest.sys"
+  - "system32\\drivers\\VBoxSF.sys"
+  - "system32\\drivers\\VBoxVideo.sys"
+  - "system32\\vboxdisp.dll"
+  - "system32\\vboxhook.dll"
+  - "system32\\vboxmrxnp.dll"
+  - "system32\\vboxogl.dll"
+  - "system32\\vboxoglarrayspu.dll"
+  - "system32\\vboxoglcrutil.dll"
+  - "system32\\vboxoglerrorspu.dll"
+  - "system32\\vboxoglfeedbackspu.dll"
+  - "system32\\vboxoglpackspu.dll"
+  - "system32\\vboxoglpassthroughspu.dll"
+  - "system32\\vboxservice.exe"
+  - "system32\\vboxtray.exe"
+  - "system32\\VBoxControl.exe"
+  - "system32\\drivers\\vmmouse.sys"
+  - "system32\\drivers\\vmhgfs.sys"
 
 - **Directories artifacts**
-	- "%PROGRAMFILES%\\oracle\\virtualbox guest additions\\"
-	- "%PROGRAMFILES%\\VMWare\\"
+  - "%PROGRAMFILES%\\oracle\\virtualbox guest additions\\"
+  - "%PROGRAMFILES%\\VMWare\\"
 
 - **Memory artifacts**
-	- Interupt Descriptor Table (IDT) location
-	- Local Descriptor Table (LDT) location
-	- Global Descriptor Table (GDT) location
-	- Task state segment trick with STR
+  - Interupt Descriptor Table (IDT) location
+  - Local Descriptor Table (LDT) location
+  - Global Descriptor Table (GDT) location
+  - Task state segment trick with STR
 
 - **MAC Address**
-	- "\x08\x00\x27" (VBOX)
-	- "\x00\x05\x69" (VMWARE)
-	- "\x00\x0C\x29" (VMWARE)
-	- "\x00\x1C\x14" (VMWARE)
-	- "\x00\x50\x56" (VMWARE)
+  - "\x08\x00\x27" (VBOX)
+  - "\x00\x05\x69" (VMWARE)
+  - "\x00\x0C\x29" (VMWARE)
+  - "\x00\x1C\x14" (VMWARE)
+  - "\x00\x50\x56" (VMWARE)
 
 - **Virtual devices**
-	- "\\\\.\\VBoxMiniRdrDN"
-	- "\\\\.\\VBoxGuest"
-	- "\\\\.\\pipe\\VBoxMiniRdDN"
-	- "\\\\.\\VBoxTrayIPC"
-	- "\\\\.\\pipe\\VBoxTrayIPC")
-	- "\\\\.\\HGFS"
-	- "\\\\.\\vmci"
+  - "\\\\.\\VBoxMiniRdrDN"
+  - "\\\\.\\VBoxGuest"
+  - "\\\\.\\pipe\\VBoxMiniRdDN"
+  - "\\\\.\\VBoxTrayIPC"
+  - "\\\\.\\pipe\\VBoxTrayIPC")
+  - "\\\\.\\HGFS"
+  - "\\\\.\\vmci"
 
 - **Hardware Device information**
-	- SetupAPI SetupDiEnumDeviceInfo (GUID_DEVCLASS_DISKDRIVE) 
-		- QEMU
-		- VMWare
-		- VBOX
-		- VIRTUAL HD
+  - SetupAPI SetupDiEnumDeviceInfo (GUID_DEVCLASS_DISKDRIVE) 
+    - QEMU
+    - VMWare
+    - VBOX
+    - VIRTUAL HD
 
 - **Adapter name**
-	- VMWare
+  - VMWare
 
 - **Windows Class**
-	- VBoxTrayToolWndClass
-	- VBoxTrayToolWnd
+  - VBoxTrayToolWndClass
+  - VBoxTrayToolWnd
 
 - **Network shares**
-	- VirtualBox Shared Folders
+  - VirtualBox Shared Folders
 
 - **Processes**
-	- vboxservice.exe	(VBOX)
-	- vboxtray.exe		(VBOX)
-	- vmtoolsd.exe		(VMWARE)
-	- vmwaretray.exe	(VMWARE)
-	- vmwareuser		(VMWARE)
-	- vmsrvc.exe		(VirtualPC)
-	- vmusrvc.exe		(VirtualPC)
-	- prl_cc.exe		(Parallels)
-	- prl_tools.exe		(Parallels)
-	- xenservice.exe	(Citrix Xen)
+  - vboxservice.exe	(VBOX)
+    - vboxtray.exe	(VBOX)
+      - vmtoolsd.exe(VMWARE)
+    - vmwaretray.exe(VMWARE)
+      - vmwareuser(VMWARE)
+      - vmsrvc.exe(VirtualPC)
+      - vmusrvc.exe(VirtualPC)
+      - prl_cc.exe(Parallels)
+      - prl_tools.exe(Parallels)
+    - xenservice.exe(Citrix Xen)
 
 - **WMI**
-	- SELECT * FROM Win32_Bios (SerialNumber) (VMWARE)
-	- SELECT * FROM Win32_PnPEntity (DeviceId) (VBOX)
-	- SELECT * FROM Win32_NetworkAdapterConfiguration (MACAddress) (VBOX)
-	- SELECT * FROM Win32_NTEventlogFile (VBOX)
-	- SELECT * FROM Win32_Processor (NumberOfCores) (GENERIC)
-	- SELECT * FROM Win32_LogicalDisk (Size) (GENERIC)
+  - SELECT * FROM Win32_Bios (SerialNumber) (VMWARE)
+  - SELECT * FROM Win32_PnPEntity (DeviceId) (VBOX)
+  - SELECT * FROM Win32_NetworkAdapterConfiguration (MACAddress) (VBOX)
+  - SELECT * FROM Win32_NTEventlogFile (VBOX)
+  - SELECT * FROM Win32_Processor (NumberOfCores) (GENERIC)
+  - SELECT * FROM Win32_LogicalDisk (Size) (GENERIC)
 
 - **DLL Exports and Loaded DLLs**
-	- kernel32.dll!wine_get_unix_file_nameWine (Wine)
-	- sbiedll.dll (Sandboxie)
-	- dbghelp.dll (MS debugging support routines)
-	- api_log.dll (iDefense Labs)
-	- dir_watch.dll (iDefense Labs)
-	- pstorec.dll (SunBelt Sandbox)
-	- vmcheck.dll (Virtual PC)
-	- wpespy.dll (WPE Pro)
+  - kernel32.dll!wine_get_unix_file_nameWine (Wine)
+  - sbiedll.dll (Sandboxie)
+  - dbghelp.dll (MS debugging support routines)
+  - api_log.dll (iDefense Labs)
+  - dir_watch.dll (iDefense Labs)
+  - pstorec.dll (SunBelt Sandbox)
+  - vmcheck.dll (Virtual PC)
+  - wpespy.dll (WPE Pro)
 
 - **CPU**
-	- Hypervisor presence using (EAX=0x1)
-	- Hypervisor vendor using (EAX=0x40000000)
-		- "KVMKVMKVM\0\0\0"	(KVM)
-		- "Microsoft Hv"	(Microsoft Hyper-V or Windows Virtual PC)
-		- "VMwareVMware"	(VMware)
-		- "XenVMMXenVMM"	(Xen)
-		- "prl hyperv  "	( Parallels)
-		 -"VBoxVBoxVBox"	( VirtualBox)
+  - Hypervisor presence using (EAX=0x1)
+  - Hypervisor vendor using (EAX=0x40000000)
+    - "KVMKVMKVM\0\0\0"	(KVM)
+      - "Microsoft Hv"(Microsoft Hyper-V or Windows Virtual PC)
+      - "VMwareVMware"(VMware)
+      - "XenVMMXenVMM"(Xen)
+      - "prl hyperv  "( Parallels)
+         -"VBoxVBoxVBox"( VirtualBox)
 
 
 ### Anti-Analysis
 - **Processes**
-	- OllyDBG / ImmunityDebugger / WinDbg / IDA Pro
-	- SysInternals Suite Tools (Process Explorer / Process Monitor / Regmon / Filemon, TCPView, Autoruns)
-	- Wireshark / Dumpcap
-	- ProcessHacker / SysAnalyzer / HookExplorer / SysInspector
-	- ImportREC / PETools / LordPE
-	- JoeBox Sandbox
+  - OllyDBG / ImmunityDebugger / WinDbg / IDA Pro
+  - SysInternals Suite Tools (Process Explorer / Process Monitor / Regmon / Filemon, TCPView, Autoruns)
+  - Wireshark / Dumpcap
+  - ProcessHacker / SysAnalyzer / HookExplorer / SysInspector
+  - ImportREC / PETools / LordPE
+  - JoeBox Sandbox
 
 ### Macro malware attacks
 - Document_Close / Auto_Close.

--- a/al-khaser/Al-khaser.cpp
+++ b/al-khaser/Al-khaser.cpp
@@ -42,6 +42,7 @@ int main(void)
 	exec_check(&SetHandleInformatiom_ProtectedHandle, TEXT("Checking CloseHandle protected handle trick : "));
 	exec_check(&NtQuerySystemInformation_SystemKernelDebuggerInformation, TEXT("Checking NtQuerySystemInformation with SystemKernelDebuggerInformation : "));
 	exec_check(&SharedUserData_KernelDebugger, TEXT("Checking SharedUserData->KdDebuggerEnabled : "));
+	exec_check(&ProcessJob, TEXT("Checking if process in in a job : "));
 
 	/* Generic sandbox detection */
 	print_category(TEXT("Generic Sandboxe/VM Detection"));

--- a/al-khaser/Anti Debug/ProcessJob.cpp
+++ b/al-khaser/Anti Debug/ProcessJob.cpp
@@ -1,0 +1,71 @@
+#include "ProcessJob.h"
+
+/*
+ * ProcessJob  -  Contributed by Graham Sutherland (https://github.com/gsuberland)
+ * 
+ * Checks whether the process is part of a job object and, if so, any non-whitelisted processes are part of that job.
+ * 
+ * Debuggers and other analysis applications usually place processes inside a job so that child processes will exit
+ * when the parent process exits.
+ * You can observe this with Visual Studio by running al-khaser with Debug -> Start Without Debugging.
+ *
+ */
+
+BOOL ProcessJob()
+{
+	BOOL foundProblem = TRUE;
+
+	DWORD jobProcessStructSize = sizeof(JOBOBJECT_BASIC_PROCESS_ID_LIST) + sizeof(ULONG_PTR) * 1024;
+	JOBOBJECT_BASIC_PROCESS_ID_LIST* jobProcessIdList = static_cast<JOBOBJECT_BASIC_PROCESS_ID_LIST*>(malloc(jobProcessStructSize));
+
+	SecureZeroMemory(jobProcessIdList, jobProcessStructSize);
+
+	jobProcessIdList->NumberOfProcessIdsInList = 1024;
+
+	if (QueryInformationJobObject(NULL, JobObjectBasicProcessIdList, jobProcessIdList, jobProcessStructSize, NULL) == TRUE)
+	{
+		int ok_processes = 0;
+		for (DWORD i = 0; i < jobProcessIdList->NumberOfAssignedProcesses; i++)
+		{
+			ULONG_PTR processId = jobProcessIdList->ProcessIdList[i];
+
+			// is this the current process? if so that's ok
+			if (processId == (ULONG_PTR)GetCurrentProcessId())
+			{
+				ok_processes++;
+			}
+			else
+			{
+				// find the process name for this job process
+				HANDLE hJobProcess = OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, processId);
+				if (hJobProcess != NULL)
+				{
+					const int processNameBufferSize = 4096;
+					LPTSTR processName = static_cast<LPTSTR>(malloc(sizeof(TCHAR) * processNameBufferSize));
+					SecureZeroMemory(processName, sizeof(TCHAR) * processNameBufferSize);
+
+					if (GetProcessImageFileName(hJobProcess, processName, processNameBufferSize) > 0)
+					{
+						String pnStr(processName);
+
+						// ignore conhost.exe (this hosts the al-khaser executable in a console)
+						if (pnStr.find(String(L"\\Windows\\System32\\conhost.exe")) != std::string::npos)
+						{
+							ok_processes++;
+						}
+					}
+
+					free(processName);
+				}
+				CloseHandle(hJobProcess);
+			}
+		}
+
+		// if we found other processes in the job other than the current process and conhost, report a problem
+		foundProblem = ok_processes != jobProcessIdList->NumberOfAssignedProcesses;
+	}
+
+	free(jobProcessIdList);
+
+	return foundProblem;
+}

--- a/al-khaser/Anti Debug/ProcessJob.h
+++ b/al-khaser/Anti Debug/ProcessJob.h
@@ -1,0 +1,12 @@
+#include <Windows.h>
+#include <Winternl.h>
+#include <Psapi.h>
+#include <string>
+
+#ifndef UNICODE  
+typedef std::string String;
+#else
+typedef std::wstring String;
+#endif
+
+BOOL ProcessJob();

--- a/al-khaser/Shared/Main.h
+++ b/al-khaser/Shared/Main.h
@@ -28,6 +28,7 @@
 #include "..\Anti Debug\TLS_callbacks.h"
 #include "..\Anti Debug\NtQuerySystemInformation_SystemKernelDebuggerInformation.h"
 #include "..\Anti Debug\SharedUserData_KernelDebugger.h"
+#include "..\Anti Debug\ProcessJob.h"
 
 /* Anti dumping headers */
 #include "..\Anti Dump\ErasePEHeaderFromMemory.h"

--- a/al-khaser/al-khaser.vcxproj
+++ b/al-khaser/al-khaser.vcxproj
@@ -183,6 +183,7 @@
     <ClCompile Include="Anti Debug\ProcessHeap_Flags.cpp" />
     <ClCompile Include="Anti Debug\ProcessHeap_ForceFlags.cpp" />
     <ClCompile Include="Anti Debug\ProcessHeap_NtGlobalFlag.cpp" />
+    <ClCompile Include="Anti Debug\ProcessJob.cpp" />
     <ClCompile Include="Anti Debug\SeDebugPrivilege.cpp" />
     <ClCompile Include="Anti Debug\SetHandleInformation_API.cpp" />
     <ClCompile Include="Anti Debug\SharedUserData_KernelDebugger.cpp" />
@@ -233,6 +234,7 @@
     <ClInclude Include="Anti Debug\ProcessHeap_Flags.h" />
     <ClInclude Include="Anti Debug\ProcessHeap_ForceFlags.h" />
     <ClInclude Include="Anti Debug\ProcessHeap_NtGlobalFlag.h" />
+    <ClInclude Include="Anti Debug\ProcessJob.h" />
     <ClInclude Include="Anti Debug\SeDebugPrivilege.h" />
     <ClInclude Include="Anti Debug\SetHandleInformation_API.h" />
     <ClInclude Include="Anti Debug\SharedUserData_KernelDebugger.h" />

--- a/al-khaser/al-khaser.vcxproj.filters
+++ b/al-khaser/al-khaser.vcxproj.filters
@@ -225,6 +225,9 @@
     <ClCompile Include="Anti Debug\SharedUserData_KernelDebugger.cpp">
       <Filter>Anti Debug\Source</Filter>
     </ClCompile>
+    <ClCompile Include="Anti Debug\ProcessJob.cpp">
+      <Filter>Anti Debug\Source</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Shared\VersionHelpers.h">
@@ -378,6 +381,9 @@
       <Filter>Anti Debug\Header</Filter>
     </ClInclude>
     <ClInclude Include="Anti Debug\SharedUserData_KernelDebugger.h">
+      <Filter>Anti Debug\Header</Filter>
+    </ClInclude>
+    <ClInclude Include="Anti Debug\ProcessJob.h">
       <Filter>Anti Debug\Header</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Debugging applications commonly place debugees into a job object for various reasons, e.g. so that the child processes are closed if the parent crashes. We can exploit this to identify cases where the al-khaser process is part of a job, excluding some edge cases (e.g. console hosting). This new check identifies if the current process is part of a job and, if so, enumerates the job objects to see if any of them are outside a whitelist.

You can test this check by running the al-khaser process from within Visual Studio via Debug -> Start Without Debugging.