### PR TITLE
Fix null references in timing.cpp

### DIFF
--- a/al-khaser/timing-attacks/timing.cpp
+++ b/al-khaser/timing-attacks/timing.cpp
@@ -25,6 +25,7 @@ VOID timing_NtDelayexecution(UINT delayInMilliSeconds)
 		// Handle however.. chances of this failing
 		// is essentially 0 however since
 		// ntdll.dll is a vital system resource
+		printf("Failed to open a handle to NTDLL... this is suspicious!\n");
 	}
 
 	NtDelayExecution = (pNtDelayExecution)GetProcAddress(hNtdll, "NtDelayExecution");
@@ -32,6 +33,7 @@ VOID timing_NtDelayexecution(UINT delayInMilliSeconds)
 	{
 		// Handle however it fits your needs but as before,
 		// if this is missing there are some SERIOUS issues with the OS
+		printf("NTDLL does not have an NtDelayExecution entry point... this is suspicious!\n");
 	}
 
 	// Time to finally make the call

--- a/al-khaser/timing-attacks/timing.cpp
+++ b/al-khaser/timing-attacks/timing.cpp
@@ -26,6 +26,7 @@ VOID timing_NtDelayexecution(UINT delayInMilliSeconds)
 		// is essentially 0 however since
 		// ntdll.dll is a vital system resource
 		printf("Failed to open a handle to NTDLL... this is suspicious!\n");
+		return;
 	}
 
 	NtDelayExecution = (pNtDelayExecution)GetProcAddress(hNtdll, "NtDelayExecution");
@@ -34,6 +35,7 @@ VOID timing_NtDelayexecution(UINT delayInMilliSeconds)
 		// Handle however it fits your needs but as before,
 		// if this is missing there are some SERIOUS issues with the OS
 		printf("NTDLL does not have an NtDelayExecution entry point... this is suspicious!\n");
+		return;
 	}
 
 	// Time to finally make the call


### PR DESCRIPTION
Previously had no check to see if the DLL / API lookups succeeded, causing null ref if they did.

These calls can fail in sandboxes where the calls are filtered.