### PR TITLE
Memory write watch anti-debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Please, if you encounter any of the anti-analysis tricks which you have seen in 
 - NtYieldExecution / SwitchToThread
 - TLS callbacks
 - Process jobs
-
+- Memory write watching
 
 
 ### Anti-Dumping

--- a/al-khaser/Al-khaser.cpp
+++ b/al-khaser/Al-khaser.cpp
@@ -14,6 +14,7 @@ int main(void)
 	if (IsWoW64())
 		_tprintf(_T("Process is running under WOW64\n\n"));
 
+	
 	/* Debugger Detection */
 	print_category(TEXT("Debugger Detection"));
 	exec_check(&IsDebuggerPresentAPI, TEXT("Checking IsDebuggerPresent API () "));
@@ -43,6 +44,10 @@ int main(void)
 	exec_check(&NtQuerySystemInformation_SystemKernelDebuggerInformation, TEXT("Checking NtQuerySystemInformation with SystemKernelDebuggerInformation : "));
 	exec_check(&SharedUserData_KernelDebugger, TEXT("Checking SharedUserData->KdDebuggerEnabled : "));
 	exec_check(&ProcessJob, TEXT("Checking if process in in a job : "));
+	exec_check(&VirtualAlloc_WriteWatch_BufferOnly, TEXT("Checking VirtualAlloc write watch (buffer only) "));
+	exec_check(&VirtualAlloc_WriteWatch_APICall, TEXT("Checking VirtualAlloc write watch (API call) "));
+	exec_check(&VirtualAlloc_WriteWatch_IsDebuggerPresent, TEXT("Checking VirtualAlloc write watch (IsDebuggerPresent) "));
+	exec_check(&VirtualAlloc_WriteWatch_CodeWrite, TEXT("Checking VirtualAlloc write watch (code write) "));
 
 	/* Generic sandbox detection */
 	print_category(TEXT("Generic Sandboxe/VM Detection"));

--- a/al-khaser/Anti Debug/WriteWatch.cpp
+++ b/al-khaser/Anti Debug/WriteWatch.cpp
@@ -1,0 +1,217 @@
+#include <Windows.h>
+#include <tchar.h>
+#include <cstdio>
+
+/*
+ * This check uses the MEM_WRITE_WATCH feature of VirtualAlloc to test for additional memory writes by debuggers, sandboxing, etc.
+ * There are a few ways that we can exploit this:
+ *  (1) Allocate a buffer, write it once, get the count, see if it's >1
+ *  (2) Allocate a buffer, pass it to an API where we know the buffer isn't touched (e.g. call with invalid parameter) and see if the count is >0
+ *  (3) Allocate a buffer, use it to store a result of a call we care about (e.g. IsDebuggerPresent) and see if the memory was hit exactly once
+ *  (4) Allocate an executable buffer, copy a debug check routine to it, run the check, see if any writes were performed after ours.
+ *
+ * Reference: https://msdn.microsoft.com/en-us/library/windows/desktop/aa366887.aspx
+ * GetWriteWatch: https://msdn.microsoft.com/en-us/library/windows/desktop/aa366573.aspx
+ * 
+ */
+
+BOOL VirtualAlloc_WriteWatch_BufferOnly()
+{
+	PVOID* addresses = static_cast<PVOID*>(VirtualAlloc(NULL, 4096 * sizeof(PVOID), MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE));
+	ULONG_PTR hitCount;
+	DWORD granularity;
+	BOOL result;
+
+	int* buffer = static_cast<int*>(VirtualAlloc(NULL, 4096 * 4096, MEM_RESERVE | MEM_COMMIT | MEM_WRITE_WATCH, PAGE_READWRITE));
+	// read the buffer once
+	buffer[0] = 1234;
+	
+	hitCount = 4096;
+	if (GetWriteWatch(0, buffer, 4096, addresses, &hitCount, &granularity) != 0)
+	{
+		printf("GetWriteWatch failed. Last error: %d\n", GetLastError());
+		result = FALSE;
+	}
+	else
+	{
+		// should only have one read here
+		result = hitCount != 1;
+	}
+
+	VirtualFree(addresses, 0, MEM_RELEASE);
+	VirtualFree(buffer, 0, MEM_RELEASE);
+
+	return result;
+}
+
+BOOL VirtualAlloc_WriteWatch_APICall()
+{
+	PVOID* addresses = static_cast<PVOID*>(VirtualAlloc(NULL, 4096 * sizeof(PVOID), MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE));
+	ULONG_PTR hitCount;
+	DWORD granularity;
+	BOOL result;
+
+	int* buffer = static_cast<int*>(VirtualAlloc(NULL, 4096 * 4096, MEM_RESERVE | MEM_COMMIT | MEM_WRITE_WATCH, PAGE_READWRITE));
+	if (GlobalGetAtomName(INVALID_ATOM, (LPTSTR)buffer, 1) != 0)
+	{
+		// uh, wut?
+		printf("GlobalGetAtomName succeeded when it should've failed... not sure what happened!\n");
+		result = FALSE;
+	}
+	else
+	{
+		// ReadProcessMemory failed as it should have! :)
+
+		hitCount = 4096;
+		if (GetWriteWatch(0, buffer, 4096, addresses, &hitCount, &granularity) != 0)
+		{
+			printf("GetWriteWatch failed. Last error: %d\n", GetLastError());
+			result = FALSE;
+		}
+		else
+		{
+			// should have zero reads here because GlobalGetAtomName doesn't probe the buffer until other checks have succeeded
+			// if there's an API hook or debugger in here it'll probably try to probe the buffer, which will be caught here
+			result = hitCount != 0;
+		}
+	}
+
+	VirtualFree(addresses, 0, MEM_RELEASE);
+	VirtualFree(buffer, 0, MEM_RELEASE);
+
+	return result;
+}
+
+BOOL VirtualAlloc_WriteWatch_IsDebuggerPresent()
+{
+	PVOID* addresses = static_cast<PVOID*>(VirtualAlloc(NULL, 4096 * sizeof(PVOID), MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE));
+	ULONG_PTR hitCount;
+	DWORD granularity;
+	BOOL result;
+
+	int* buffer = static_cast<int*>(VirtualAlloc(NULL, 4096 * 4096, MEM_RESERVE | MEM_COMMIT | MEM_WRITE_WATCH, PAGE_READWRITE));
+	buffer[0] = IsDebuggerPresent();
+
+	hitCount = 4096;
+	if (GetWriteWatch(0, buffer, 4096, addresses, &hitCount, &granularity) != 0)
+	{
+		printf("GetWriteWatch failed. Last error: %d\n", GetLastError());
+		result = FALSE;
+	}
+	else
+	{
+		// should only have one write here
+		result = (hitCount != 1) | (buffer[0] == TRUE);
+	}
+
+	VirtualFree(addresses, 0, MEM_RELEASE);
+	VirtualFree(buffer, 0, MEM_RELEASE);
+
+	return result;
+}
+
+BOOL VirtualAlloc_WriteWatch_CodeWrite()
+{
+	PVOID* addresses = static_cast<PVOID*>(VirtualAlloc(NULL, 4096 * sizeof(PVOID), MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE));
+	ULONG_PTR hitCount, initialHitCount;
+	DWORD granularity;
+	BOOL result;
+
+	byte* buffer = static_cast<byte*>(VirtualAlloc(NULL, 4096 * 4096, MEM_RESERVE | MEM_COMMIT | MEM_WRITE_WATCH, PAGE_EXECUTE_READWRITE));
+	
+	// construct a call to isDebuggerPresent in assembly
+	ULONG_PTR isDebuggerPresentAddr = (ULONG_PTR)&IsDebuggerPresent;
+
+#ifndef _WIN32
+#ifndef _WIN64
+#error Architecture must be WIN32 or WIN64
+#endif
+#endif
+
+
+#if _WIN64
+	/*
+	 * 64-bit
+	 *
+		0:  51                              push   rcx
+		1:  48 b9 ef cd ab 90 78 56 34 12   movabs rcx, 0x1234567890abcdef
+		b:  ff d1                           call   rcx
+		d:  59                              pop    rcx
+	    e:  c3                              ret
+	 */
+	int pos = 0;
+	buffer[pos++] = 0x51; // push rcx
+	buffer[pos++] = 0x48; // movabs rcx, ...
+	buffer[pos++] = 0xB9; // ^ ...
+	int offset = 0;
+	for (int n = 0; n < 8; n++)
+	{
+		buffer[pos++] = (isDebuggerPresentAddr >> offset) & 0xFF;
+		offset += 8;
+	}
+	buffer[pos++] = 0xFF; // call rcx
+	buffer[pos++] = 0xD1; // ^
+	buffer[pos++] = 0x59; // pop rcx
+	buffer[pos  ] = 0xC3; // ret
+
+#else
+	/*
+	 * 32-bit
+	 *
+	0:  51                      push   ecx
+	1:  b9 78 56 34 12          mov    ecx, 0x12345678
+	6:  ff d1                   call   ecx
+	8:  59                      pop    ecx
+	9:  c3                      ret
+	*/
+	int pos = 0;
+	buffer[pos++] = 0x51; // push ecx
+	buffer[pos++] = 0xB9; // mov ecx, ...
+	int offset = 0;
+	for (int n = 0; n < 4; n++)
+	{
+		buffer[pos++] = (isDebuggerPresentAddr >> offset) & 0xFF;
+		offset += 8;
+	}
+	buffer[pos++] = 0xFF; // call ecx
+	buffer[pos++] = 0xD1; // ^
+	buffer[pos++] = 0x59; // pop ecx
+	buffer[pos] = 0xC3; // ret
+
+#endif
+
+	initialHitCount = 4096;
+	if (GetWriteWatch(0, buffer, 4096, addresses, &initialHitCount, &granularity) != 0)
+	{
+		printf("GetWriteWatch failed. Last error: %d\n", GetLastError());
+		result = FALSE;
+	}
+	else
+	{
+		// cool, now exec the code
+		BOOL(*foo)(VOID) = (BOOL(*)(VOID))buffer;
+		if (foo() == TRUE)
+		{
+			result = TRUE;
+		}
+
+		if (result == FALSE)
+		{
+			hitCount = 4096;
+			if (GetWriteWatch(0, buffer, 4096, addresses, &hitCount, &granularity) != 0)
+			{
+				printf("GetWriteWatch failed. Last error: %d\n", GetLastError());
+				result = FALSE;
+			}
+			else
+			{
+				result = hitCount != initialHitCount;
+			}
+		}
+	}
+
+	VirtualFree(addresses, 0, MEM_RELEASE);
+	VirtualFree(buffer, 0, MEM_RELEASE);
+
+	return result;
+}

--- a/al-khaser/Anti Debug/WriteWatch.h
+++ b/al-khaser/Anti Debug/WriteWatch.h
@@ -1,0 +1,7 @@
+#include <Windows.h>
+
+
+BOOL VirtualAlloc_WriteWatch_BufferOnly();
+BOOL VirtualAlloc_WriteWatch_APICall();
+BOOL VirtualAlloc_WriteWatch_IsDebuggerPresent();
+BOOL VirtualAlloc_WriteWatch_CodeWrite();

--- a/al-khaser/Shared/Main.h
+++ b/al-khaser/Shared/Main.h
@@ -29,6 +29,7 @@
 #include "..\Anti Debug\NtQuerySystemInformation_SystemKernelDebuggerInformation.h"
 #include "..\Anti Debug\SharedUserData_KernelDebugger.h"
 #include "..\Anti Debug\ProcessJob.h"
+#include "..\Anti Debug\WriteWatch.h"
 
 /* Anti dumping headers */
 #include "..\Anti Dump\ErasePEHeaderFromMemory.h"

--- a/al-khaser/al-khaser.vcxproj
+++ b/al-khaser/al-khaser.vcxproj
@@ -190,6 +190,7 @@
     <ClCompile Include="Anti Debug\SoftwareBreakpoints.cpp" />
     <ClCompile Include="Anti Debug\TLS_callbacks.cpp" />
     <ClCompile Include="Anti Debug\UnhandledExceptionFilter_Handler.cpp" />
+    <ClCompile Include="Anti Debug\WriteWatch.cpp" />
     <ClCompile Include="Anti Dump\ErasePEHeaderFromMemory.cpp" />
     <ClCompile Include="Anti Dump\SizeOfImage.cpp" />
     <ClCompile Include="Anti VM\Generic.cpp" />
@@ -243,6 +244,7 @@
     <ClInclude Include="Anti Debug\SoftwareBreakpoints.h" />
     <ClInclude Include="Anti Debug\TLS_callbacks.h" />
     <ClInclude Include="Anti Debug\UnhandledExceptionFilter_Handler.h" />
+    <ClInclude Include="Anti Debug\WriteWatch.h" />
     <ClInclude Include="Anti Dump\ErasePEHeaderFromMemory.h" />
     <ClInclude Include="Anti Dump\SizeOfImage.h" />
     <ClInclude Include="Anti VM\Generic.h" />

--- a/al-khaser/al-khaser.vcxproj.filters
+++ b/al-khaser/al-khaser.vcxproj.filters
@@ -234,6 +234,9 @@
     <ClCompile Include="Anti VM\Services.cpp">
       <Filter>Anti VM / Emulation\Source</Filter>
     </ClCompile>
+    <ClCompile Include="Anti Debug\WriteWatch.cpp">
+      <Filter>Anti Debug\Source</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Shared\VersionHelpers.h">
@@ -397,6 +400,9 @@
     </ClInclude>
     <ClInclude Include="Anti VM\Services.h">
       <Filter>Anti VM / Emulation\Header</Filter>
+    </ClInclude>
+    <ClInclude Include="Anti Debug\WriteWatch.h">
+      <Filter>Anti Debug\Header</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Using VirtualAlloc's MEM_WRITE_WATCH and associated APIs to look for hooks and debuggers.

Writeup here:

https://codeinsecurity.wordpress.com/2018/01/24/anti-debug-with-virtualallocs-write-watch/