### PR TITLE
Vastly improved VirtualAlloc write watch tests

### DIFF
--- a/al-khaser/Al-khaser.cpp
+++ b/al-khaser/Al-khaser.cpp
@@ -45,7 +45,7 @@ int main(void)
 	exec_check(&SharedUserData_KernelDebugger, TEXT("Checking SharedUserData->KdDebuggerEnabled : "));
 	exec_check(&ProcessJob, TEXT("Checking if process in in a job : "));
 	exec_check(&VirtualAlloc_WriteWatch_BufferOnly, TEXT("Checking VirtualAlloc write watch (buffer only) "));
-	exec_check(&VirtualAlloc_WriteWatch_APICall, TEXT("Checking VirtualAlloc write watch (API call) "));
+	exec_check(&VirtualAlloc_WriteWatch_APICalls, TEXT("Checking VirtualAlloc write watch (API calls) "));
 	exec_check(&VirtualAlloc_WriteWatch_IsDebuggerPresent, TEXT("Checking VirtualAlloc write watch (IsDebuggerPresent) "));
 	exec_check(&VirtualAlloc_WriteWatch_CodeWrite, TEXT("Checking VirtualAlloc write watch (code write) "));
 

--- a/al-khaser/Anti Debug/WriteWatch.h
+++ b/al-khaser/Anti Debug/WriteWatch.h
@@ -2,6 +2,6 @@
 
 
 BOOL VirtualAlloc_WriteWatch_BufferOnly();
-BOOL VirtualAlloc_WriteWatch_APICall();
+BOOL VirtualAlloc_WriteWatch_APICalls();
 BOOL VirtualAlloc_WriteWatch_IsDebuggerPresent();
 BOOL VirtualAlloc_WriteWatch_CodeWrite();


### PR DESCRIPTION
New test cases with multiple APIs.

This might need some testing across Windows versions to avoid false positives, but I suspect it won't be a problem as we're relying only on reference parameters not being written to when invalid parameters are passed to APIs, which is unlikely to change across versions.