### PR TITLE
XP Support

### DIFF
--- a/al-khaser/Anti VM/Qemu.cpp
+++ b/al-khaser/Anti VM/Qemu.cpp
@@ -87,7 +87,7 @@ BOOL qemu_firmware_ACPI()
 
 	PDWORD tableNames = static_cast<PDWORD>(malloc(4096));
 	SecureZeroMemory(tableNames, 4096);
-	DWORD tableSize = EnumSystemFirmwareTables(static_cast<DWORD>('ACPI'), tableNames, 4096);
+	DWORD tableSize = enum_system_firmware_tables(static_cast<DWORD>('ACPI'), tableNames, 4096);
 	DWORD tableCount = tableSize / 4;
 	if (tableSize < 4 || tableCount == 0)
 		result = TRUE;
@@ -112,6 +112,7 @@ BOOL qemu_firmware_ACPI()
 		}
 	}
 
+lblCleanup:
 	free(tableNames);
 	return result;
 }

--- a/al-khaser/Anti VM/VMWare.cpp
+++ b/al-khaser/Anti VM/VMWare.cpp
@@ -237,7 +237,7 @@ BOOL vmware_firmware_ACPI()
 
 	PDWORD tableNames = static_cast<PDWORD>(malloc(4096));
 	SecureZeroMemory(tableNames, 4096);
-	DWORD tableSize = EnumSystemFirmwareTables(static_cast<DWORD>('ACPI'), tableNames, 4096);
+	DWORD tableSize = enum_system_firmware_tables(static_cast<DWORD>('ACPI'), tableNames, 4096);
 	DWORD tableCount = tableSize / 4;
 	if (tableSize < 4 || tableCount == 0)
 		result = TRUE;
@@ -259,6 +259,7 @@ BOOL vmware_firmware_ACPI()
 		}
 	}
 
+lblCleanup:
 	free(tableNames);
 	return result;
 }

--- a/al-khaser/Anti VM/VirtualBox.cpp
+++ b/al-khaser/Anti VM/VirtualBox.cpp
@@ -451,7 +451,7 @@ BOOL vbox_firmware_ACPI()
 
 	PDWORD tableNames = static_cast<PDWORD>(malloc(4096));
 	SecureZeroMemory(tableNames, 4096);
-	DWORD tableSize = EnumSystemFirmwareTables(static_cast<DWORD>('ACPI'), tableNames, 4096);
+	DWORD tableSize = enum_system_firmware_tables(static_cast<DWORD>('ACPI'), tableNames, 4096);
 	DWORD tableCount = tableSize / 4;
 	if (tableSize < 4 || tableCount == 0)
 		result = TRUE;
@@ -480,6 +480,7 @@ BOOL vbox_firmware_ACPI()
 		}
 	}
 
+lblCleanup:
 	free(tableNames);
 	return result;
 }

--- a/al-khaser/Shared/Utils.h
+++ b/al-khaser/Shared/Utils.h
@@ -37,6 +37,7 @@ ULONG get_gdt_base();
 UCHAR* get_str_base();
 BOOL IsElevated();
 BOOL find_str_in_data(PBYTE needle, size_t needleLen, PBYTE haystack, size_t haystackLen);
+UINT enum_system_firmware_tables(_In_ DWORD FirmwareTableProviderSignature, _Out_ PVOID pFirmwareTableBuffer, _In_ DWORD BufferSize);
 PBYTE get_system_firmware(_In_ DWORD signature, _In_ DWORD table, _Out_ PDWORD pBufferSize);
 
 #define	MALLOC(x)	HeapAlloc(GetProcessHeap(), 0, x)


### PR DESCRIPTION
Call GetProcAddress to obtain pointers to EnumSystemFirmwareTables and GetSystemFirmwareTable since they aren't available on XP.