### PR TITLE
TLS callback improvements

### DIFF
--- a/al-khaser/Al-khaser.cpp
+++ b/al-khaser/Al-khaser.cpp
@@ -4,6 +4,7 @@
 int main(void)
 {
 	/* enable functions */
+	BOOL	ENABLE_TLS_CHECKS = TRUE;
 	BOOL	ENABLE_DEBUG_CHECKS = TRUE;
 	BOOL	ENABLE_GEN_SANDBOX_CHECKS = TRUE;
 	BOOL	ENABLE_VBOX_CHECKS = TRUE;
@@ -27,6 +28,13 @@ int main(void)
 
 	if (IsWoW64())
 		_tprintf(_T("Process is running under WOW64\n\n"));
+
+	/* TLS checks */
+	if (ENABLE_TLS_CHECKS) {
+		print_category(TEXT("TLS Callbacks"));
+		exec_check(&TLSCallbackProcess, TEXT("TLS process attach callback "));
+		exec_check(&TLSCallbackThread, TEXT("TLS thread attach callback "));
+	}
 
 	/* Debugger Detection */
 	if (ENABLE_DEBUG_CHECKS) {

--- a/al-khaser/Anti Debug/TLS_callbacks.cpp
+++ b/al-khaser/Anti Debug/TLS_callbacks.cpp
@@ -21,7 +21,6 @@ VOID WINAPI tls_callback(PVOID hModule, DWORD dwReason, PVOID pContext)
 	{
 		if (tls_callback_data != NULL)
 		{
-			OutputDebugString(_TEXT("In thread attach, setting up event."));
 			HANDLE hThreadEvent = (HANDLE)tls_callback_data[TLS_CALLBACK_OFS_THREAD_EVENT_HANDLE];
 			tls_callback_data[TLS_CALLBACK_OFS_THREAD] = 0xDEADBEEF;
 			SetEvent(hThreadEvent);

--- a/al-khaser/Anti Debug/TLS_callbacks.cpp
+++ b/al-khaser/Anti Debug/TLS_callbacks.cpp
@@ -2,20 +2,81 @@
 
 // The Thread Local Storage (TLS) callback is called before the execution of the EntryPoint of the application
 // Malware takes advantages to perform anti-debug and anti-vm checks.
-// Their could be more than one callback, and sometimes, inside one call back, one can create one in the fly.
+// There could be more than one callback, and sometimes, inside one call back, one can create one in the fly.
 
-VOID  WINAPI tls_callback(PVOID hModule, DWORD dwReason, PVOID pContext)
+
+volatile bool has_run = false;
+
+VOID WINAPI tls_callback(PVOID hModule, DWORD dwReason, PVOID pContext)
 {
+	if (!has_run)
+	{
+		has_run = true;
+		tls_callback_data = (UINT64*)VirtualAlloc(NULL, 0x1000, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
+		tls_callback_data[TLS_CALLBACK_OFS_THREAD_EVENT_HANDLE] = (UINT64)CreateEvent(NULL, FALSE, FALSE, NULL);
+		tls_callback_data[TLS_CALLBACK_OFS_PROCESS_EVENT_HANDLE] = (UINT64)CreateEvent(NULL, FALSE, FALSE, NULL);
+	}
+
 	if (dwReason == DLL_THREAD_ATTACH)
 	{
-		// This will be loaded in each DLL thread attach
-		// MessageBox(0, _T("I am running from a TLS callbacks, did you see that?"), _T("DLL_THREAD_ATTACH"), 0);
+		if (tls_callback_data != NULL)
+		{
+			OutputDebugString(_TEXT("In thread attach, setting up event."));
+			HANDLE hThreadEvent = (HANDLE)tls_callback_data[TLS_CALLBACK_OFS_THREAD_EVENT_HANDLE];
+			tls_callback_data[TLS_CALLBACK_OFS_THREAD] = 0xDEADBEEF;
+			SetEvent(hThreadEvent);
+		}
 	}
 
 	if (dwReason == DLL_PROCESS_ATTACH)
 	{
-		MessageBox(0, _T("I am running from a TLS callbacks, did you see that?"), _T("DLL_PROCESS_ATTACH"), 0);
+		if (tls_callback_data != NULL)
+		{
+			HANDLE hProcEvent = (HANDLE)tls_callback_data[TLS_CALLBACK_OFS_PROCESS_EVENT_HANDLE];
+			tls_callback_data[TLS_CALLBACK_OFS_PROCESS] = 0xDEADBEEF;
+			SetEvent(hProcEvent);
+		}
 	}
+}
+
+BOOL TLSCallbackThread()
+{
+	const int BLOWN = 1000;
+
+	int fuse = 0;
+	while (tls_callback_data == NULL && ++fuse != BLOWN) { SwitchToThread(); }
+	if (fuse == BLOWN)
+		return TRUE;
+
+	fuse = 0;
+	while (tls_callback_data[TLS_CALLBACK_OFS_THREAD_EVENT_HANDLE] == NULL && ++fuse != BLOWN) { SwitchToThread(); }
+	if (fuse == BLOWN)
+		return TRUE;
+
+	if (WaitForSingleObject((HANDLE)tls_callback_data[TLS_CALLBACK_OFS_THREAD_EVENT_HANDLE], 2000) != WAIT_OBJECT_0)
+		return TRUE;
+
+	return tls_callback_data[TLS_CALLBACK_OFS_THREAD] == 0xDEADBEEF ? FALSE : TRUE;
+}
+
+BOOL TLSCallbackProcess()
+{
+	const int BLOWN = 1000;
+
+	int fuse = 0;
+	while (tls_callback_data == NULL && ++fuse != BLOWN) { SwitchToThread(); }
+	if (fuse == BLOWN)
+		return TRUE;
+
+	fuse = 0;
+	while (tls_callback_data[TLS_CALLBACK_OFS_PROCESS_EVENT_HANDLE] == NULL && ++fuse != BLOWN) { SwitchToThread(); }
+	if (fuse == BLOWN)
+		return TRUE;
+
+	if (WaitForSingleObject((HANDLE)tls_callback_data[TLS_CALLBACK_OFS_PROCESS_EVENT_HANDLE], 2000) != WAIT_OBJECT_0)
+		return TRUE;
+
+	return tls_callback_data[TLS_CALLBACK_OFS_PROCESS] == 0xDEADBEEF ? FALSE : TRUE;
 }
 
 #ifdef _WIN64

--- a/al-khaser/Anti Debug/TLS_callbacks.h
+++ b/al-khaser/Anti Debug/TLS_callbacks.h
@@ -1,11 +1,10 @@
 #include <Windows.h>
 #include <tchar.h>
 
-const int TLS_CALLBACK_OFS_THREAD_EVENT_HANDLE = 1;
-const int TLS_CALLBACK_OFS_PROCESS_EVENT_HANDLE = 1;
-const int TLS_CALLBACK_OFS_THREAD = 2;
-const int TLS_CALLBACK_OFS_PROCESS = 3;
-static volatile UINT64* tls_callback_data = NULL;
+static volatile HANDLE tls_callback_thread_event;
+static volatile HANDLE tls_callback_process_event;
+static volatile UINT32 tls_callback_thread_data;
+static volatile UINT32 tls_callback_process_data;
 
 VOID WINAPI tls_callback(PVOID hModule, DWORD dwReason, PVOID pContext);
 BOOL TLSCallbackThread();

--- a/al-khaser/Anti Debug/TLS_callbacks.h
+++ b/al-khaser/Anti Debug/TLS_callbacks.h
@@ -1,4 +1,12 @@
 #include <Windows.h>
 #include <tchar.h>
 
-VOID  WINAPI tls_callback(PVOID hModule, DWORD dwReason, PVOID pContext);
+const int TLS_CALLBACK_OFS_THREAD_EVENT_HANDLE = 1;
+const int TLS_CALLBACK_OFS_PROCESS_EVENT_HANDLE = 1;
+const int TLS_CALLBACK_OFS_THREAD = 2;
+const int TLS_CALLBACK_OFS_PROCESS = 3;
+static volatile UINT64* tls_callback_data = NULL;
+
+VOID WINAPI tls_callback(PVOID hModule, DWORD dwReason, PVOID pContext);
+BOOL TLSCallbackThread();
+BOOL TLSCallbackProcess();


### PR DESCRIPTION
Re-wrote TLS callbacks as a check rather than message box to avoid forcing user interaction. This means that organisations can use al-khaser in CI and other automated testing for builds (e.g. for sandbox products) more easily.