### PR TITLE
Overhaul of timing attack code + fix the locky timer trick

### DIFF
--- a/al-khaser/Al-khaser.cpp
+++ b/al-khaser/Al-khaser.cpp
@@ -176,41 +176,18 @@ int main(void)
 	/* Timing Attacks */
 	if (ENABLE_TIMING_ATTACKS) {
 		print_category(TEXT("Timing-attacks"));
-		UINT delayInSeconds = 300U;
-		UINT delayInMilliSeconds = delayInSeconds * 1000U;
+		UINT delayInSeconds = 600U;
+		UINT delayInMillis = delayInSeconds * 1000U;
 		printf("\n[*] Delay value is set to %u minutes ...\n", delayInSeconds / 60);
 
-		_tprintf(_T("[+] Performing a sleep using NtDelayExecution ...\n"));
-		timing_NtDelayexecution(delayInMilliSeconds);
-		print_results(FALSE, _T("NtDelayexecution was bypassed!"));
-
-		_tprintf(_T("[+] Performing a sleep() in a loop ...\n"));
-		timing_sleep_loop(delayInMilliSeconds);
-		print_results(FALSE, _T("Sleep in loop was bypassed!"));
-
-		_tprintf(_T("[*] Delaying execution using SetTimer ...\n"));
-		timing_SetTimer(delayInMilliSeconds);
-		print_results(FALSE, _T("timing_SetTimer was bypassed!"));
-
-		_tprintf(_T("[*] Delaying execution using timeSetEvent ...\n"));
-		timing_timeSetEvent(delayInMilliSeconds);
-		print_results(FALSE, _T("timeSetEvent was bypassed!"));
-
-		_tprintf(_T("[*] Delaying execution using WaitForSingleObject ...\n"));
-		timing_WaitForSingleObject(delayInMilliSeconds);
-		print_results(FALSE, _T("WaitForSingleObject was bypassed!"));
-
-		_tprintf(_T("[*] Delaying execution using IcmpSendEcho ...\n"));
-		timing_IcmpSendEcho(delayInMilliSeconds);
-		print_results(FALSE, _T("IcmpSendEcho was bypassed!"));
-
-		_tprintf(_T("[*] Delaying execution using CreateWaitableTimer ...\n"));
-		timing_CreateWaitableTimer(delayInMilliSeconds);
-		print_results(FALSE, _T("CreateWaitableTimer was bypassed!"));
-
-		_tprintf(_T("[*] Delaying execution using CreateTimerQueueTimer ...\n"));
-		timing_CreateTimerQueueTimer(delayInMilliSeconds);
-		print_results(FALSE, _T("CreateTimerQueueTimer was bypassed!"));
+		exec_check(timing_NtDelayexecution, delayInMillis, TEXT("Performing a sleep using NtDelayExecution ..."));
+		exec_check(timing_sleep_loop, delayInMillis, TEXT("Performing a sleep() in a loop ..."));
+		exec_check(timing_SetTimer, delayInMillis, TEXT("Delaying execution using SetTimer ..."));
+		exec_check(timing_timeSetEvent, delayInMillis, TEXT("Delaying execution using timeSetEvent ..."));
+		exec_check(timing_WaitForSingleObject, delayInMillis, TEXT("Delaying execution using WaitForSingleObject ..."));
+		exec_check(timing_IcmpSendEcho, delayInMillis, TEXT("Delaying execution using IcmpSendEcho ..."));
+		exec_check(timing_CreateWaitableTimer, delayInMillis, TEXT("Delaying execution using CreateWaitableTimer ..."));
+		exec_check(timing_CreateTimerQueueTimer, delayInMillis, TEXT("Delaying execution using CreateTimerQueueTimer ..."));
 
 		exec_check(&rdtsc_diff_locky, TEXT("Checking RDTSC Locky trick "));
 		exec_check(&rdtsc_diff_vmexit, TEXT("Checking RDTSC which force a VM Exit (cpuid) "));

--- a/al-khaser/Shared/Common.cpp
+++ b/al-khaser/Shared/Common.cpp
@@ -81,7 +81,8 @@ VOID print_results(int result, TCHAR* szMsg)
 	_print_check_result(result, szMsg);
 }
 
-VOID exec_check(int(*callback)(), TCHAR* szMsg) 
+// note: templated version of this function is in Common.h
+VOID exec_check(int(*callback)(), TCHAR* szMsg)
 {
 	/* Print the text to screen so we can see what's currently running */
 	_print_check_text(szMsg);

--- a/al-khaser/Shared/Common.h
+++ b/al-khaser/Shared/Common.h
@@ -1,14 +1,15 @@
+#ifndef __AL_KHASER_COMMON_H__
+#define __AL_KHASER_COMMON_H__
+
 #include <Windows.h>
 #include <stdio.h>
 #include <tchar.h>
 #include <strsafe.h>
 
-
 VOID print_detected() ;
 VOID print_not_detected() ;
 VOID print_category(TCHAR* text);
 VOID print_last_error(LPTSTR lpszFunction);
-VOID exec_check(int(*callback)(), TCHAR* text_log);
 VOID print_os();
 TCHAR* ascii_to_wide_str(CHAR* lpMultiByteStr);
 CHAR* wide_str_to_multibyte(TCHAR* lpWideStr);
@@ -16,3 +17,23 @@ VOID resize_console_window();
 VOID print_results(int result, TCHAR* szMsg);
 VOID _print_check_text(TCHAR* szMsg);
 VOID _print_check_result(int result, TCHAR* szMsg);
+
+VOID exec_check(int(*callback)(), TCHAR* szMsg);
+
+// this must be defined in this header file
+// see: https://stackoverflow.com/questions/495021/why-can-templates-only-be-implemented-in-the-header-file
+template <typename T>
+VOID exec_check(int(*callback)(T param), T param, TCHAR* szMsg)
+{
+	/* Print the text to screen so we can see what's currently running */
+	_print_check_text(szMsg);
+
+	/* Call our check */
+	int result = callback(param);
+
+	/* Print / Log the result */
+	if (szMsg)
+		_print_check_result(result, szMsg);
+}
+
+#endif

--- a/al-khaser/timing-attacks/timing.h
+++ b/al-khaser/timing-attacks/timing.h
@@ -8,15 +8,16 @@
 #pragma comment(lib, "Winmm.lib")
 
 #include "..\Shared\Common.h"
+#include "..\Shared\VersionHelpers.h"
 
-VOID timing_SetTimer(UINT delayInMilliSeconds);
-VOID timing_NtDelayexecution(UINT delayInMilliSeconds);
-VOID timing_timeSetEvent(UINT delayInMilliSeconds);
-VOID timing_WaitForSingleObject(UINT delayInMilliSeconds);
-VOID timing_sleep_loop(UINT delayInMilliSeconds);
+BOOL timing_SetTimer(UINT delayInMillis);
+BOOL timing_NtDelayexecution(UINT delayInMillis);
+BOOL timing_timeSetEvent(UINT delayInMillis);
+BOOL timing_WaitForSingleObject(UINT delayInMillis);
+BOOL timing_sleep_loop(UINT delayInMillis);
 BOOL rdtsc_diff_locky();
 BOOL rdtsc_diff_vmexit();
-VOID timing_IcmpSendEcho(UINT delayInMilliSeconds);
-BOOL timing_CreateWaitableTimer(UINT delayInMilliSeconds);
-BOOL timing_CreateTimerQueueTimer(UINT delayInMilliSeconds);
+BOOL timing_IcmpSendEcho(UINT delayInMillis);
+BOOL timing_CreateWaitableTimer(UINT delayInMillis);
+BOOL timing_CreateTimerQueueTimer(UINT delayInMillis);
 VOID CALLBACK CallbackCTQT(PVOID lParam, BOOLEAN TimerOrWaitFired);


### PR DESCRIPTION
This overhauls how we do the timing attack stuff, so we can use exec_check on those functions and return a sensible status based on whether APIs returned expected values. In the process I noticed the locky timer trick had the return values backwards so I fixed that too.

See #114 for more info (I'll close it when this PR is resolved)