### PR TITLE
Bug fixes 5

### DIFF
--- a/al-khaser/AntiAnalysis/process.cpp
+++ b/al-khaser/AntiAnalysis/process.cpp
@@ -33,14 +33,14 @@ VOID analysis_tools_process()
 		_T("sniff_hit.exe"),		// Part of SysAnalyzer iDefense
 		_T("windbg.exe"),			// Microsoft WinDbg
 		_T("joeboxcontrol.exe"),	// Part of Joe Sandbox
-		_T("joeboxserver.exe"),		// Part of Joe Sandbox
+		_T("joeboxserver.exe")		// Part of Joe Sandbox
 	};
 
 	WORD iLength = sizeof(szProcesses) / sizeof(szProcesses[0]);
 	for (int i = 0; i < iLength; i++)
 	{
 		TCHAR msg[256] = _T("");
-		_stprintf_s(msg, sizeof(msg) / sizeof(TCHAR), _T("Checking process of malware analysis tool: %s: "), szProcesses[i]);
+		_stprintf_s(msg, sizeof(msg) / sizeof(TCHAR), _T("Checking process of malware analysis tool: %s "), szProcesses[i]);
 		if (GetProcessIdFromName(szProcesses[i]))
 			print_results(TRUE, msg);
 		else

--- a/al-khaser/AntiDebug/HardwareBreakpoints.cpp
+++ b/al-khaser/AntiDebug/HardwareBreakpoints.cpp
@@ -11,23 +11,31 @@ Dr0 through Dr3 are 32 bit registers that hold the address of the breakpoint .
 
 BOOL HardwareBreakpoints()
 {
+	BOOL bResult = FALSE;
+
 	// This structure is key to the function and is the 
 	// medium for detection and removal
 	PCONTEXT ctx = PCONTEXT(VirtualAlloc(NULL, sizeof(CONTEXT), MEM_COMMIT, PAGE_READWRITE));
-	SecureZeroMemory(ctx, sizeof(CONTEXT));
 
-	// The CONTEXT structure is an in/out parameter therefore we have
-	// to set the flags so Get/SetThreadContext knows what to set or get.
-	ctx->ContextFlags = CONTEXT_DEBUG_REGISTERS;
+	if (ctx) {
 
-	// Get the registers
-	if (GetThreadContext(GetCurrentThread(), ctx) == 0)
-		return -1;
+		SecureZeroMemory(ctx, sizeof(CONTEXT));
 
-	// Now we can check for hardware breakpoints, its not 
-	// necessary to check Dr6 and Dr7, however feel free to
-	if (ctx->Dr0 != 0 || ctx->Dr1 != 0 || ctx->Dr2 != 0 || ctx->Dr3 != 0)
-		return TRUE;
-	else
-		return FALSE;
+		// The CONTEXT structure is an in/out parameter therefore we have
+		// to set the flags so Get/SetThreadContext knows what to set or get.
+		ctx->ContextFlags = CONTEXT_DEBUG_REGISTERS;
+
+		// Get the registers
+		if (GetThreadContext(GetCurrentThread(), ctx)) {
+
+			// Now we can check for hardware breakpoints, its not 
+			// necessary to check Dr6 and Dr7, however feel free to
+			if (ctx->Dr0 != 0 || ctx->Dr1 != 0 || ctx->Dr2 != 0 || ctx->Dr3 != 0)
+				bResult = TRUE;
+		}
+
+		VirtualFree(ctx, 0, MEM_RELEASE);
+	}
+
+	return bResult;
 }

--- a/al-khaser/AntiDebug/MemoryBreakpoints_PageGuard.cpp
+++ b/al-khaser/AntiDebug/MemoryBreakpoints_PageGuard.cpp
@@ -38,10 +38,10 @@ BOOL MemoryBreakpoints_PageGuard()
 	}
 	__except (GetExceptionCode() == STATUS_GUARD_PAGE_VIOLATION ? EXCEPTION_EXECUTE_HANDLER : EXCEPTION_CONTINUE_SEARCH)
 	{
-		VirtualFree(pAllocation, NULL, MEM_RELEASE);
+		VirtualFree(pAllocation, 0, MEM_RELEASE);
 		return FALSE;
 	}
 
-	VirtualFree(pAllocation, NULL, MEM_RELEASE);
+	VirtualFree(pAllocation, 0, MEM_RELEASE);
 	return TRUE;
 }

--- a/al-khaser/AntiDebug/ModuleBoundsHookCheck.cpp
+++ b/al-khaser/AntiDebug/ModuleBoundsHookCheck.cpp
@@ -65,7 +65,7 @@ char apis_user32[] = "ActivateKeyboardLayout AddClipboardFormatListener AdjustWi
 bool ModuleBoundsHookCheckSingle(HMODULE dll, char* apiList)
 {
 	MODULEINFO moduleInfo;
-	if (GetModuleInformation(GetCurrentProcess(), dll, &moduleInfo, sizeof(MODULEINFO)) != TRUE)
+	if (GetModuleInformation(GetCurrentProcess(), dll, &moduleInfo, sizeof(MODULEINFO)) == FALSE)
 	{
 		// todo: error condition
 		return FALSE;

--- a/al-khaser/AntiDebug/PageExceptionBreakpointCheck.cpp
+++ b/al-khaser/AntiDebug/PageExceptionBreakpointCheck.cpp
@@ -20,10 +20,10 @@ void PageExceptionInitialEnum()
 	MEMORY_BASIC_INFORMATION memInfo = { 0 };
 
 	// Get the main module handle from an address stored within it (pointer to this method)
-	if (GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCWSTR)PageExceptionBreakpointCheck, &hMainModule) == TRUE)
+	if (GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCWSTR)PageExceptionBreakpointCheck, &hMainModule))
 	{
 		// Get information about the main module (we want to know the size of it)
-		if (GetModuleInformation(GetCurrentProcess(), hMainModule, &moduleInfo, sizeof(MODULEINFO)) == TRUE)
+		if (GetModuleInformation(GetCurrentProcess(), hMainModule, &moduleInfo, sizeof(MODULEINFO)))
 		{
 			// cast the module to a pointer
 			unsigned char* module = static_cast<unsigned char*>(moduleInfo.lpBaseOfDll);
@@ -60,10 +60,10 @@ BOOL PageExceptionBreakpointCheck()
 	// first we check if any of the pages are executable+guard or noaccess
 
 	// Get the main module handle from an address stored within it (pointer to this method)
-	if (GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCWSTR)PageExceptionBreakpointCheck, &hMainModule) == TRUE)
+	if (GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCWSTR)PageExceptionBreakpointCheck, &hMainModule))
 	{
 		// Get information about the main module (we want to know the size of it)
-		if (GetModuleInformation(GetCurrentProcess(), hMainModule, &moduleInfo, sizeof(MODULEINFO)) == TRUE)
+		if (GetModuleInformation(GetCurrentProcess(), hMainModule, &moduleInfo, sizeof(MODULEINFO)))
 		{
 			// cast the module to a pointer
 			unsigned char* module = static_cast<unsigned char*>(moduleInfo.lpBaseOfDll);

--- a/al-khaser/AntiDebug/ProcessJob.cpp
+++ b/al-khaser/AntiDebug/ProcessJob.cpp
@@ -26,7 +26,7 @@ BOOL ProcessJob()
 
 		jobProcessIdList->NumberOfProcessIdsInList = 1024;
 
-		if (QueryInformationJobObject(NULL, JobObjectBasicProcessIdList, jobProcessIdList, jobProcessStructSize, NULL) == TRUE)
+		if (QueryInformationJobObject(NULL, JobObjectBasicProcessIdList, jobProcessIdList, jobProcessStructSize, NULL))
 		{
 			int ok_processes = 0;
 			for (DWORD i = 0; i < jobProcessIdList->NumberOfAssignedProcesses; i++)

--- a/al-khaser/AntiDebug/ScanForModules.cpp
+++ b/al-khaser/AntiDebug/ScanForModules.cpp
@@ -64,6 +64,14 @@ static HRESULT NormalizeNTPath(TCHAR* pszPath, size_t nMax)
 	return E_FAIL;
 }
 
+bool IsGlobalizationNls(TCHAR* filename)
+{
+	// exclude this nls
+	// consider removing this hack with proper implementation of memory scan
+	PCTSTR ret = StrStrI(filename, _T("\\Windows\\Globalization\\Sorting\\SortDefault.nls"));
+	return (ret != NULL);
+}
+
 bool IsBadLibrary(TCHAR* filename, DWORD filenameLength)
 {
 	TCHAR systemDrive[MAX_PATH];
@@ -71,6 +79,9 @@ bool IsBadLibrary(TCHAR* filename, DWORD filenameLength)
 	TCHAR systemRootPath[MAX_PATH];
 	TCHAR exePath[MAX_PATH];
 	TCHAR normalisedPath[MAX_PATH];
+
+	if (IsGlobalizationNls(filename))
+		return false;
 
 	StringCbCopy(normalisedPath, MAX_PATH, filename);
 	NormalizeNTPath(normalisedPath, MAX_PATH);
@@ -101,7 +112,7 @@ bool IsBadLibrary(TCHAR* filename, DWORD filenameLength)
 
 			//printf("systemDriveDevice: %S (%d)\n", systemDriveDevice, systemDriveDevicelength);
 
-			if (StrNCmpI(systemDriveDevice, filename, min(systemDriveDevicelength, filenameLength) / sizeof(TCHAR)) == 0)
+			if (StrNCmpI(systemDriveDevice, filename, (int)(min(systemDriveDevicelength, filenameLength) / sizeof(TCHAR)) ) == 0)
 			{
 				// path matched the NT file path
 				return false;
@@ -113,7 +124,7 @@ bool IsBadLibrary(TCHAR* filename, DWORD filenameLength)
 
 			//printf("systemRootPath: %S (%d)\n", systemRootPath, systemRootPathLength);
 
-			if (StrNCmpI(systemRootPath, normalisedPath, min(systemRootPathLength, normalisedPathLength) / sizeof(TCHAR)) == 0)
+			if (StrNCmpI(systemRootPath, normalisedPath, (int)(min(systemRootPathLength, normalisedPathLength) / sizeof(TCHAR)) ) == 0)
 			{
 				// path matched the regular system path
 				return false;

--- a/al-khaser/AntiDebug/ScanForModules.cpp
+++ b/al-khaser/AntiDebug/ScanForModules.cpp
@@ -73,7 +73,7 @@ bool IsBadLibrary(TCHAR* filename, DWORD filenameLength)
 	TCHAR normalisedPath[MAX_PATH];
 
 	StringCbCopy(normalisedPath, MAX_PATH, filename);
-	NormalizeNTPath(filename, MAX_PATH);
+	NormalizeNTPath(normalisedPath, MAX_PATH);
 	size_t normalisedPathLength = 0;
 	StringCbLength(normalisedPath, MAX_PATH, &normalisedPathLength);
 

--- a/al-khaser/AntiDebug/ScanForModules.cpp
+++ b/al-khaser/AntiDebug/ScanForModules.cpp
@@ -152,7 +152,7 @@ BOOL ScanForModules_EnumProcessModulesEx_Internal(DWORD moduleFlag)
 	moduleList = static_cast<HMODULE*>(calloc(1024, sizeof(HMODULE)));
 	if (moduleList) {
 
-		if (EnumProcessModulesEx(GetCurrentProcess(), moduleList, currentSize, &requiredSize, moduleFlag) == TRUE)
+		if (EnumProcessModulesEx(GetCurrentProcess(), moduleList, currentSize, &requiredSize, moduleFlag))
 		{
 			bool success = true;
 			if (requiredSize > currentSize)
@@ -241,7 +241,7 @@ BOOL ScanForModules_MemoryWalk_GMI()
 			{
 				if (memInfo.State != MEM_FREE)
 				{
-					if (GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, (TCHAR*)addr, &moduleHandle) == TRUE)
+					if (GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, (TCHAR*)addr, &moduleHandle))
 					{
 						SecureZeroMemory(moduleName, MAX_PATH * sizeof(TCHAR));
 						DWORD len = GetModuleFileName(moduleHandle, moduleName, MAX_PATH);
@@ -251,7 +251,7 @@ BOOL ScanForModules_MemoryWalk_GMI()
 							printf(" [!] Injected library: %S\n", moduleName);
 						anyBadLibs |= isBad;
 
-						if (GetModuleInformation(GetCurrentProcess(), moduleHandle, &moduleInfo, sizeof(MODULEINFO)) == TRUE)
+						if (GetModuleInformation(GetCurrentProcess(), moduleHandle, &moduleInfo, sizeof(MODULEINFO)))
 						{
 							size_t moduleSizeRoundedUp = (moduleInfo.SizeOfImage + 1);
 							moduleSizeRoundedUp += 4096 - (moduleSizeRoundedUp % 4096);
@@ -333,7 +333,7 @@ BOOL ScanForModules_MemoryWalk_Hidden()
 			else
 			{
 				MODULEINFO modInfo = { 0 };
-				if (GetModuleInformation(GetCurrentProcess(), moduleHandle, &modInfo, sizeof(MODULEINFO)) == TRUE)
+				if (GetModuleInformation(GetCurrentProcess(), moduleHandle, &modInfo, sizeof(MODULEINFO)))
 				{
 					size_t moduleSizeRoundedUp = (modInfo.SizeOfImage + 1);
 					moduleSizeRoundedUp += 4096 - (moduleSizeRoundedUp % 4096);
@@ -559,7 +559,7 @@ BOOL ScanForModules_ToolHelp32()
 	//printf("Snapshot: %p\n", snapshot);
 	if (snapshot == INVALID_HANDLE_VALUE)
 	{
-		printf("Failed to get snapshot. Last error: %d\n", GetLastError());
+		printf("Failed to get snapshot. Last error: %u\n", GetLastError());
 	}
 	else
 	{
@@ -579,7 +579,7 @@ BOOL ScanForModules_ToolHelp32()
 		}
 		else
 		{
-			printf("Failed to get first module. Last error: %d\n", GetLastError());
+			printf("Failed to get first module. Last error: %u\n", GetLastError());
 		}
 
 		CloseHandle(snapshot);

--- a/al-khaser/AntiDebug/WriteWatch.cpp
+++ b/al-khaser/AntiDebug/WriteWatch.cpp
@@ -105,7 +105,7 @@ BOOL VirtualAlloc_WriteWatch_APICalls()
 		hitCount = 4096;
 		if (GetWriteWatch(0, buffer, 4096, addresses, &hitCount, &granularity) != 0)
 		{
-			printf("GetWriteWatch failed. Last error: %d\n", GetLastError());
+			printf("GetWriteWatch failed. Last error: %u\n", GetLastError());
 			result = FALSE;
 		}
 		else
@@ -139,7 +139,7 @@ BOOL VirtualAlloc_WriteWatch_IsDebuggerPresent()
 	hitCount = 4096;
 	if (GetWriteWatch(0, buffer, 4096, addresses, &hitCount, &granularity) != 0)
 	{
-		printf("GetWriteWatch failed. Last error: %d\n", GetLastError());
+		printf("GetWriteWatch failed. Last error: %u\n", GetLastError());
 		result = FALSE;
 	}
 	else
@@ -238,7 +238,7 @@ BOOL VirtualAlloc_WriteWatch_CodeWrite()
 		hitCount = 4096;
 		if (GetWriteWatch(0, buffer, 4096, addresses, &hitCount, &granularity) != 0)
 		{
-			printf("GetWriteWatch failed. Last error: %d\n", GetLastError());
+			printf("GetWriteWatch failed. Last error: %u\n", GetLastError());
 			result = FALSE;
 		}
 		else

--- a/al-khaser/AntiDebug/WriteWatch.cpp
+++ b/al-khaser/AntiDebug/WriteWatch.cpp
@@ -16,19 +16,30 @@
 
 BOOL VirtualAlloc_WriteWatch_BufferOnly()
 {
-	PVOID* addresses = static_cast<PVOID*>(VirtualAlloc(NULL, 4096 * sizeof(PVOID), MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE));
 	ULONG_PTR hitCount;
 	DWORD granularity;
-	BOOL result;
+	BOOL result = FALSE;
+
+	PVOID* addresses = static_cast<PVOID*>(VirtualAlloc(NULL, 4096 * sizeof(PVOID), MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE));
+	if (addresses == NULL) {
+		printf("VirtualAlloc failed. Last error: %u\n", GetLastError());
+		return result;
+	}
 
 	int* buffer = static_cast<int*>(VirtualAlloc(NULL, 4096 * 4096, MEM_RESERVE | MEM_COMMIT | MEM_WRITE_WATCH, PAGE_READWRITE));
+	if (buffer == NULL) {
+		VirtualFree(addresses, 0, MEM_RELEASE);
+		printf("VirtualAlloc failed. Last error: %u\n", GetLastError());
+		return result;
+	}
+
 	// read the buffer once
 	buffer[0] = 1234;
 	
 	hitCount = 4096;
 	if (GetWriteWatch(0, buffer, 4096, addresses, &hitCount, &granularity) != 0)
 	{
-		printf("GetWriteWatch failed. Last error: %d\n", GetLastError());
+		printf("GetWriteWatch failed. Last error: %u\n", GetLastError());
 		result = FALSE;
 	}
 	else
@@ -45,12 +56,22 @@ BOOL VirtualAlloc_WriteWatch_BufferOnly()
 
 BOOL VirtualAlloc_WriteWatch_APICalls()
 {
-	PVOID* addresses = static_cast<PVOID*>(VirtualAlloc(NULL, 4096 * sizeof(PVOID), MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE));
 	ULONG_PTR hitCount;
 	DWORD granularity;
-	BOOL result, error = FALSE;
+	BOOL result = FALSE, error = FALSE;
+
+	PVOID* addresses = static_cast<PVOID*>(VirtualAlloc(NULL, 4096 * sizeof(PVOID), MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE));
+	if (addresses == NULL) {
+		printf("VirtualAlloc failed. Last error: %u\n", GetLastError());
+		return result;
+	}
 
 	int* buffer = static_cast<int*>(VirtualAlloc(NULL, 4096 * 4096, MEM_RESERVE | MEM_COMMIT | MEM_WRITE_WATCH, PAGE_READWRITE));
+	if (buffer == NULL) {
+		VirtualFree(addresses, 0, MEM_RELEASE);
+		printf("VirtualAlloc failed. Last error: %u\n", GetLastError());
+		return result;
+	}
 
 	// make a bunch of calls where buffer *can* be written to, but isn't actually touched due to invalid parameters.
 	// this can catch out API hooks whose return-by-parameter behaviour is different to that of regular APIs
@@ -128,12 +149,23 @@ BOOL VirtualAlloc_WriteWatch_APICalls()
 
 BOOL VirtualAlloc_WriteWatch_IsDebuggerPresent()
 {
-	PVOID* addresses = static_cast<PVOID*>(VirtualAlloc(NULL, 4096 * sizeof(PVOID), MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE));
 	ULONG_PTR hitCount;
 	DWORD granularity;
-	BOOL result;
+	BOOL result = FALSE;
+
+	PVOID* addresses = static_cast<PVOID*>(VirtualAlloc(NULL, 4096 * sizeof(PVOID), MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE));
+	if (addresses == NULL) {
+		printf("VirtualAlloc failed. Last error: %u\n", GetLastError());
+		return result;
+	}
 
 	int* buffer = static_cast<int*>(VirtualAlloc(NULL, 4096 * 4096, MEM_RESERVE | MEM_COMMIT | MEM_WRITE_WATCH, PAGE_READWRITE));
+	if (buffer == NULL) {
+		VirtualFree(addresses, 0, MEM_RELEASE);
+		printf("VirtualAlloc failed. Last error: %u\n", GetLastError());
+		return result;
+	}
+
 	buffer[0] = IsDebuggerPresent();
 
 	hitCount = 4096;
@@ -156,12 +188,22 @@ BOOL VirtualAlloc_WriteWatch_IsDebuggerPresent()
 
 BOOL VirtualAlloc_WriteWatch_CodeWrite()
 {
-	PVOID* addresses = static_cast<PVOID*>(VirtualAlloc(NULL, 4096 * sizeof(PVOID), MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE));
 	ULONG_PTR hitCount;
 	DWORD granularity;
 	BOOL result = FALSE;
 
+	PVOID* addresses = static_cast<PVOID*>(VirtualAlloc(NULL, 4096 * sizeof(PVOID), MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE));
+	if (addresses == NULL) {
+		printf("VirtualAlloc failed. Last error: %u\n", GetLastError());
+		return result;
+	}
+
 	byte* buffer = static_cast<byte*>(VirtualAlloc(NULL, 4096 * 4096, MEM_RESERVE | MEM_COMMIT | MEM_WRITE_WATCH, PAGE_EXECUTE_READWRITE));
+	if (buffer == NULL) {
+		VirtualFree(addresses, 0, MEM_RELEASE);
+		printf("VirtualAlloc failed. Last error: %u\n", GetLastError());
+		return result;
+	}
 	
 	// construct a call to isDebuggerPresent in assembly
 	ULONG_PTR isDebuggerPresentAddr = (ULONG_PTR)&IsDebuggerPresent;

--- a/al-khaser/AntiVM/Generic.cpp
+++ b/al-khaser/AntiVM/Generic.cpp
@@ -356,7 +356,7 @@ BOOL dizk_size_deviceiocontrol()
 
 						for (DWORD i = 0; i < diskExtents->NumberOfDiskExtents; i++)
 						{
-							if (wnsprintf(physicalPathBuffer, MAX_PATH, _T("\\\\.\\PhysicalDrive%d"), diskExtents->Extents[i].DiskNumber) > 0)
+							if (wnsprintf(physicalPathBuffer, MAX_PATH, _T("\\\\.\\PhysicalDrive%u"), diskExtents->Extents[i].DiskNumber) > 0)
 							{
 								// open the physical disk
 								hDevice = CreateFile(

--- a/al-khaser/AntiVM/Generic.cpp
+++ b/al-khaser/AntiVM/Generic.cpp
@@ -178,17 +178,25 @@ BOOL number_cores_wmi()
 
 				// Get the value of the Name property
 				hRes = pclsObj->Get(_T("NumberOfCores"), 0, &vtProp, 0, 0);
-				if (V_VT(&vtProp) != VT_NULL) {
+				if (SUCCEEDED(hRes)) {
+					if (V_VT(&vtProp) != VT_NULL) {
 
-					// Do our comparaison
-					if (vtProp.uintVal < 2) {
-						bFound = TRUE; break;
+						// Do our comparaison
+						if (vtProp.uintVal < 2) {
+							bFound = TRUE;
+						}
+
+						// release the current result object
+						VariantClear(&vtProp);
 					}
-
-					// release the current result object
-					VariantClear(&vtProp);
-					pclsObj->Release();
 				}
+
+				// release class object
+				pclsObj->Release();
+
+				// break from while
+				if (bFound)
+					break;
 			}
 
 			// Cleanup
@@ -238,25 +246,32 @@ BOOL disk_size_wmi()
 
 				// Get the value of the Name property
 				hRes = pclsObj->Get(_T("Size"), 0, &vtProp, NULL, 0);
-				if (V_VT(&vtProp) != VT_NULL)
-				{
-					// convert disk size string to bytes
-					errno = 0;
-					unsigned long long diskSizeBytes = _tcstoui64_l(vtProp.bstrVal, NULL, 10, _get_current_locale());
-					// do the check only if we successfuly got the disk size
-					if (errno == 0)
+				if (SUCCEEDED(hRes)) {
+					if (V_VT(&vtProp) != VT_NULL)
 					{
-						// Do our comparison
-						if (diskSizeBytes < minHardDiskSize) { // Less than 80GB
-							bFound = TRUE;
-							break;
+						// convert disk size string to bytes
+						errno = 0;
+						unsigned long long diskSizeBytes = _tcstoui64_l(vtProp.bstrVal, NULL, 10, _get_current_locale());
+						// do the check only if we successfuly got the disk size
+						if (errno == 0)
+						{
+							// Do our comparison
+							if (diskSizeBytes < minHardDiskSize) { // Less than 80GB
+								bFound = TRUE;
+							}
 						}
-					}
 
-					// release the current result object
-					VariantClear(&vtProp);
-					pclsObj->Release();
+						// release the current result object
+						VariantClear(&vtProp);
+					}
 				}
+				
+				// release class object
+				pclsObj->Release();
+				
+				// break from while
+				if (bFound)
+					break;
 			}
 
 			// Cleanup
@@ -703,22 +718,25 @@ BOOL serial_number_bios_wmi()
 
 				// Get the value of the Name property
 				hRes = pclsObj->Get(_T("SerialNumber"), 0, &vtProp, 0, 0);
-				if (SUCCEEDED(hRes) && vtProp.vt == VT_BSTR) {
+				if (SUCCEEDED(hRes)) {				
+					if (vtProp.vt == VT_BSTR) {
 
-					// Do our comparaison
-					if (
-						(StrStrI(vtProp.bstrVal, _T("VMWare")) != 0) ||
-						(StrStrI(vtProp.bstrVal, _T("0")) != 0) || // VBox
-						(StrStrI(vtProp.bstrVal, _T("Xen")) != 0) ||
-						(StrStrI(vtProp.bstrVal, _T("Virtual")) != 0) ||
-						(StrStrI(vtProp.bstrVal, _T("A M I")) != 0)
-						)
-					{
-						VariantClear(&vtProp);
-						pclsObj->Release();
-						bFound = TRUE;
-						break;
+						// Do our comparison
+						if (
+							(StrStrI(vtProp.bstrVal, _T("VMWare")) != 0) ||
+							(StrStrI(vtProp.bstrVal, _T("0")) != 0) || // VBox
+							(StrStrI(vtProp.bstrVal, _T("Xen")) != 0) ||
+							(StrStrI(vtProp.bstrVal, _T("Virtual")) != 0) ||
+							(StrStrI(vtProp.bstrVal, _T("A M I")) != 0)
+							)
+						{
+							VariantClear(&vtProp);
+							pclsObj->Release();
+							bFound = TRUE;
+							break;
+						}
 					}
+					VariantClear(&vtProp);
 				}
 
 				// release the current result object
@@ -771,20 +789,26 @@ BOOL model_computer_system_wmi()
 
 				// Get the value of the Name property
 				hRes = pclsObj->Get(_T("Model"), 0, &vtProp, 0, 0);
+				if (SUCCEEDED(hRes)) {
+					if (vtProp.vt == VT_BSTR) {
 
-				// Do our comparaison
-				if (
-					(StrStrI(vtProp.bstrVal, _T("VirtualBox")) != 0) ||
-					(StrStrI(vtProp.bstrVal, _T("HVM domU")) != 0) || //Xen
-					(StrStrI(vtProp.bstrVal, _T("VMWare")) != 0)
-					)
-				{
-					bFound = TRUE;
-					break;
+						// Do our comparison
+						if (
+							(StrStrI(vtProp.bstrVal, _T("VirtualBox")) != 0) ||
+							(StrStrI(vtProp.bstrVal, _T("HVM domU")) != 0) || //Xen
+							(StrStrI(vtProp.bstrVal, _T("VMWare")) != 0)
+							)
+						{
+							VariantClear(&vtProp);
+							pclsObj->Release();
+							bFound = TRUE;
+							break;
+						}
+					}
+					VariantClear(&vtProp);
 				}
 
 				// release the current result object
-				VariantClear(&vtProp);
 				pclsObj->Release();
 			}
 
@@ -834,21 +858,26 @@ BOOL manufacturer_computer_system_wmi()
 
 				// Get the value of the Name property
 				hRes = pclsObj->Get(_T("Manufacturer"), 0, &vtProp, 0, 0);
+				if (SUCCEEDED(hRes)) {
+					if (vtProp.vt == VT_BSTR) {
 
-				// Do our comparaison
-				if (
-					(StrStrI(vtProp.bstrVal, _T("VMWare")) != 0) || 
-					(StrStrI(vtProp.bstrVal, _T("Xen")) != 0) ||
-					(StrStrI(vtProp.bstrVal, _T("innotek GmbH")) != 0) || // Vbox
-					(StrStrI(vtProp.bstrVal, _T("QEMU")) != 0)
-					)
-				{
-					bFound = TRUE;
-					break;
+						// Do our comparison
+						if (
+							(StrStrI(vtProp.bstrVal, _T("VMWare")) != 0) ||
+							(StrStrI(vtProp.bstrVal, _T("Xen")) != 0) ||
+							(StrStrI(vtProp.bstrVal, _T("innotek GmbH")) != 0) || // Vbox
+							(StrStrI(vtProp.bstrVal, _T("QEMU")) != 0)
+							)
+						{
+							VariantClear(&vtProp);
+							pclsObj->Release();
+							bFound = TRUE;
+							break;
+						}
+					}
+					VariantClear(&vtProp);
 				}
-
 				// release the current result object
-				VariantClear(&vtProp);
 				pclsObj->Release();
 			}
 
@@ -906,8 +935,9 @@ BOOL current_temperature_acpi_wmi()
 				// Get the value of the Name property
 				hRes = pclsObj->Get(_T("CurrentTemperature"), 0, &vtProp, 0, 0);
 				if (SUCCEEDED(hRes)) {
+					VariantClear(&vtProp);
+					pclsObj->Release();
 					break;
-
 				}
 
 				// release the current result object
@@ -961,17 +991,21 @@ BOOL process_id_processor_wmi()
 
 				// Get the value of the Name property
 				hRes = pclsObj->Get(_T("ProcessorId"), 0, &vtProp, 0, 0);
+				if (SUCCEEDED(hRes)) {
 
-				// Do our comparaison
-				if (vtProp.bstrVal== NULL)
-				{
-					bFound = TRUE;
-					break;
+					// Do our comparison
+					if (vtProp.bstrVal == NULL)
+					{
+						bFound = TRUE;
+					}
 				}
-
 				// release the current result object
 				VariantClear(&vtProp);
 				pclsObj->Release();
+
+				// break from while
+				if (bFound)
+					break;
 			}
 
 			// Cleanup
@@ -1019,7 +1053,7 @@ BOOL cpu_fan_wmi()
 	BOOL bStatus = FALSE;
 	HRESULT hRes;
 	BOOL bFound = FALSE;
-	INT iObjCount = 0;
+	ULONG uObjCount = 0;
 
 	// Init WMI
 	bStatus = InitWMI(&pSvc, &pLoc, _T("ROOT\\CIMV2"));
@@ -1040,7 +1074,8 @@ BOOL cpu_fan_wmi()
 					break;
 				}
 				else {
-					iObjCount++;
+					uObjCount++;
+					pclsObj->Release();
 				}
 			}
 
@@ -1052,7 +1087,7 @@ BOOL cpu_fan_wmi()
 		}
 	}
 
-	if (iObjCount <= 0)
+	if (uObjCount == 0)
 		bFound = TRUE;
 	return bFound;
 }

--- a/al-khaser/AntiVM/Generic.cpp
+++ b/al-khaser/AntiVM/Generic.cpp
@@ -493,24 +493,28 @@ BOOL setupdi_diskdrive()
 				// Double the size to avoid problems on 
 				// W2k MBCS systems per KB 888609. 
 				buffer = (LPTSTR)LocalAlloc(LPTR, dwSize * 2);
+				if (buffer == NULL)
+					break;
 			}
 			else
 				break;
 
 		}
 
-		// Do our comparaison
-		if ((StrStrI(buffer, _T("vbox")) != NULL) ||
-			(StrStrI(buffer, _T("vmware")) != NULL) || 
-			(StrStrI(buffer, _T("qemu")) != NULL) ||
-			(StrStrI(buffer, _T("virtual")) != NULL))
-		{
-			bFound =  TRUE;
-			break;
+		if (buffer) {
+			// Do our comparison
+			if ((StrStrI(buffer, _T("vbox")) != NULL) ||
+				(StrStrI(buffer, _T("vmware")) != NULL) ||
+				(StrStrI(buffer, _T("qemu")) != NULL) ||
+				(StrStrI(buffer, _T("virtual")) != NULL))
+			{
+				bFound = TRUE;
+				break;
+			}
 		}
 	}
 
-	if (buffer)
+	if (buffer) 
 		LocalFree(buffer);
 
 	//  Cleanup
@@ -519,11 +523,7 @@ BOOL setupdi_diskdrive()
 	if (GetLastError() != NO_ERROR && GetLastError() != ERROR_NO_MORE_ITEMS)
 		return FALSE;
 
-	if (bFound)
-		return TRUE;
-
-	else
-		return FALSE;
+	return bFound;
 }
 
 

--- a/al-khaser/AntiVM/Qemu.cpp
+++ b/al-khaser/AntiVM/Qemu.cpp
@@ -109,17 +109,20 @@ BOOL qemu_firmware_ACPI()
 				DWORD tableSize = 0;
 				PBYTE table = get_system_firmware(static_cast<DWORD>('ACPI'), tableNames[i], &tableSize);
 
-				PBYTE qemuString1 = (PBYTE)"BOCHS";
-				size_t StringLen = 4;
-				PBYTE qemuString2 = (PBYTE)"BXPC";
+				if (table) {
 
-				if (find_str_in_data(qemuString1, StringLen, table, tableSize) ||
-					find_str_in_data(qemuString2, StringLen, table, tableSize))
-				{
-					result = TRUE;
+					PBYTE qemuString1 = (PBYTE)"BOCHS";
+					size_t StringLen = 4;
+					PBYTE qemuString2 = (PBYTE)"BXPC";
+
+					if (find_str_in_data(qemuString1, StringLen, table, tableSize) ||
+						find_str_in_data(qemuString2, StringLen, table, tableSize))
+					{
+						result = TRUE;
+					}
+
+					free(table);
 				}
-
-				free(table);
 			}
 		}
 

--- a/al-khaser/AntiVM/VMWare.cpp
+++ b/al-khaser/AntiVM/VMWare.cpp
@@ -262,15 +262,17 @@ BOOL vmware_firmware_ACPI()
 			DWORD tableSize = 0;
 			PBYTE table = get_system_firmware(static_cast<DWORD>('ACPI'), tableNames[i], &tableSize);
 
-			PBYTE vmwareString = (PBYTE)"VMWARE";
-			size_t vmwwareStringLen = 6;
+			if (table) {
 
+				PBYTE vmwareString = (PBYTE)"VMWARE";
+				size_t vmwwareStringLen = 6;
 
-			if (find_str_in_data(vmwareString, vmwwareStringLen, table, tableSize)) {
-				result = TRUE;
+				if (find_str_in_data(vmwareString, vmwwareStringLen, table, tableSize)) {
+					result = TRUE;
+				}
+
+				free(table);
 			}
-
-			free(table);
 		}
 	}
 

--- a/al-khaser/AntiVM/VirtualBox.cpp
+++ b/al-khaser/AntiVM/VirtualBox.cpp
@@ -509,21 +509,24 @@ BOOL vbox_firmware_ACPI()
 			DWORD tableSize = 0;
 			PBYTE table = get_system_firmware(static_cast<DWORD>('ACPI'), tableNames[i], &tableSize);
 
-			PBYTE virtualBoxString = (PBYTE)"VirtualBox";
-			size_t virtualBoxStringLen = 10;
-			PBYTE vboxLowerString = (PBYTE)"vbox";
-			size_t vboxLowerStringLen = 4;
-			PBYTE vboxUpperString = (PBYTE)"VBOX";
-			size_t vboxUpperStringLen = 4;
+			if (table) {
 
-			if (find_str_in_data(virtualBoxString, virtualBoxStringLen, table, tableSize) ||
-				find_str_in_data(vboxLowerString, vboxLowerStringLen, table, tableSize) ||
-				find_str_in_data(vboxUpperString, vboxUpperStringLen, table, tableSize))
-			{
-				result = TRUE;
+				PBYTE virtualBoxString = (PBYTE)"VirtualBox";
+				size_t virtualBoxStringLen = 10;
+				PBYTE vboxLowerString = (PBYTE)"vbox";
+				size_t vboxLowerStringLen = 4;
+				PBYTE vboxUpperString = (PBYTE)"VBOX";
+				size_t vboxUpperStringLen = 4;
+
+				if (find_str_in_data(virtualBoxString, virtualBoxStringLen, table, tableSize) ||
+					find_str_in_data(vboxLowerString, vboxLowerStringLen, table, tableSize) ||
+					find_str_in_data(vboxUpperString, vboxUpperStringLen, table, tableSize))
+				{
+					result = TRUE;
+				}
+
+				free(table);
 			}
-
-			free(table);
 		}
 	}
 

--- a/al-khaser/CodeInjection/CreateRemoteThread.cpp
+++ b/al-khaser/CodeInjection/CreateRemoteThread.cpp
@@ -19,7 +19,7 @@ BOOL CreateRemoteThread_Injection()
 	dwProcessId = GetProcessIdFromName(_T("notepad.exe"));
 	if (dwProcessId == NULL)
 		return FALSE;
-	_tprintf(_T("\t[+] Getting proc id: %d\n"), dwProcessId);
+	_tprintf(_T("\t[+] Getting proc id: %u\n"), dwProcessId);
 
 	/* Set Debug privilege */
 	bDebugPrivilegeEnabled = SetDebugPrivileges();

--- a/al-khaser/CodeInjection/NtCreateThreadEx.cpp
+++ b/al-khaser/CodeInjection/NtCreateThreadEx.cpp
@@ -33,7 +33,7 @@ BOOL NtCreateThreadEx_Injection()
 	dwProcessId = GetProcessIdFromName(_T("notepad.exe"));
 	if (dwProcessId == 0)
 		return FALSE;
-	_tprintf(_T("\t[+] Getting proc id: %d\n"), dwProcessId);
+	_tprintf(_T("\t[+] Getting proc id: %u\n"), dwProcessId);
 
 	/* Obtain a handle the process */
 	hProcess = OpenProcess(PROCESS_ALL_ACCESS, FALSE, dwProcessId);

--- a/al-khaser/CodeInjection/QueueUserAPC.cpp
+++ b/al-khaser/CodeInjection/QueueUserAPC.cpp
@@ -2,48 +2,80 @@
 
 #include "QueueUserAPC.h"
 
+//
+//  Check whatever InjectedDLL.dll was loaded, because this dll
+//  does not provide any other way of caller notification.
+//
+BOOL IsDllInjected(DWORD dwProcessId, LPTSTR DllName)
+{
+	BOOL bFound = FALSE;
+	HANDLE hSnapshot;
+
+	hSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPMODULE, dwProcessId);
+	if (hSnapshot != INVALID_HANDLE_VALUE) {
+
+		MODULEENTRY32 me32;
+		me32.dwSize = sizeof(MODULEENTRY32);
+
+		if (Module32First(hSnapshot, &me32)) {
+
+			do {
+
+				if (StrCmpI(me32.szModule, DllName) == 0) {
+					bFound = TRUE;
+					break;
+				}
+
+			} while (Module32Next(hSnapshot, &me32));
+
+		}
+
+		CloseHandle(hSnapshot);
+	}
+
+	return bFound;
+}
+
 BOOL QueueUserAPC_Injection()
 {
-	// Some vars
 	TCHAR lpDllName[] = _T("InjectedDLL.dll");
 	TCHAR lpDllPath[MAX_PATH];
-	HMODULE hKernel32;
+
+	HANDLE hThreadSnapshot = INVALID_HANDLE_VALUE;
+
+	DWORD dwTargetProcessId, dwCurrentProcessId = GetCurrentProcessId();
+
 	HANDLE hProcess = NULL;
 	HANDLE hThread = NULL;
-	DWORD dwProcessId, dwThreadId;
+
+	HMODULE hKernel32;
+
 	FARPROC LoadLibraryAddress;
-	LPVOID lpBaseAddress;
-	BOOL bStatus;
-	DWORD dResult;
+	LPVOID lpBaseAddress = NULL;
+	BOOL bStatus = FALSE;
+
 
 	/* Get Process ID from Process name */
-	dwProcessId = GetProcessIdFromName(_T("notepad.exe"));
-	if (dwProcessId == NULL)
-		return FALSE;
-	_tprintf(_T("\t[+] Getting proc id: %d\n"), dwProcessId);
 
-	/* Obtain a handle the process */
-	hProcess = OpenProcess(PROCESS_ALL_ACCESS, FALSE, dwProcessId);
-	if (hProcess == NULL) {
-		print_last_error(_T("OpenProcess"));
+	//
+	// calc used because it has multiple threads and some of them maybe alertable.
+	//
+	dwTargetProcessId = GetProcessIdFromName(_T("calc.exe"));
+	if (dwTargetProcessId == 0)
+		dwTargetProcessId = GetProcessIdFromName(_T("win32calc.exe"));//w10 classic calc
+
+	if (dwTargetProcessId == 0) {
+		print_last_error(_T("GetProcessIdFromName"));
 		return FALSE;
 	}
 
-	/* Get thread id from process id */
-	dwThreadId = GetMainThreadId(dwProcessId);
-	if (dwThreadId == 0)
-		return FALSE;
-	_tprintf(_T("\t[+] Getting main thread id of proc id: %d\n"), dwThreadId);
-
-	/* Getting thread hanlle from thread id */
-	hThread = OpenThread(THREAD_ALL_ACCESS, FALSE, dwThreadId);
-
-	/* Obtain a handle to kernel32 */
+	/* Obtain a hmodule of kernel32 */
 	hKernel32 = GetModuleHandle(_T("kernel32.dll"));
 	if (hKernel32 == NULL) {
 		print_last_error(_T("GetModuleHandle"));
 		return FALSE;
 	}
+
 	/* Get LoadLibrary address */
 	_tprintf(_T("\t[+] Looking for LoadLibrary in kernel32\n"));
 	LoadLibraryAddress = GetProcAddress(hKernel32, "LoadLibraryW");
@@ -53,44 +85,87 @@ BOOL QueueUserAPC_Injection()
 	}
 	_tprintf(_T("\t[+] Found at 0x%p\n"), LoadLibraryAddress);
 
-	/* Get the full path of the dll */
-	GetFullPathName(lpDllName, MAX_PATH, lpDllPath, NULL);
-	_tprintf(_T("\t[+] Full DLL Path: %s\n"), lpDllPath);
+	_tprintf(_T("\t[+] Getting proc id: %u\n"), dwTargetProcessId);
 
-	// The maximum size of the file mapping object.
-	size_t dwSize = _tcslen(lpDllPath) * sizeof(TCHAR);
-
-	/* Allocate memory into the remote process */
-	_tprintf(_T("\t[+] Allocating space for the path of the DLL\n"));
-	lpBaseAddress = VirtualAllocEx(hProcess, NULL, dwSize, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
-	if (lpBaseAddress == NULL) {
-		print_last_error(_T("VirtualAllocEx"));
+	/* Obtain a handle the process */
+	hProcess = OpenProcess(PROCESS_ALL_ACCESS, FALSE, dwTargetProcessId);
+	if (hProcess == NULL) {
+		print_last_error(_T("OpenProcess"));
 		return FALSE;
 	}
 
-	/* Write to the remote process */
-	printf("\t[+] Writing into the current process space at 0x%p\n", lpBaseAddress);
-	bStatus = WriteProcessMemory(hProcess, lpBaseAddress, lpDllPath, dwSize, NULL);
-	if (bStatus == NULL) {
-		print_last_error(_T("WriteProcessMemory"));
-		return FALSE;
+	do { // not a loop
+
+		/* Get the full path of the dll */
+		GetFullPathName(lpDllName, MAX_PATH, lpDllPath, NULL);
+		_tprintf(_T("\t[+] Full DLL Path: %s\n"), lpDllPath);
+
+		// The maximum size of the string buffer.
+		SIZE_T WriteBufferSize = _tcslen(lpDllPath) * sizeof(TCHAR);
+
+		/* Allocate memory into the remote process */
+		_tprintf(_T("\t[+] Allocating space for the path of the DLL\n"));
+		lpBaseAddress = VirtualAllocEx(hProcess, NULL, WriteBufferSize, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+		if (lpBaseAddress == NULL) {
+			print_last_error(_T("VirtualAllocEx"));
+			break;
+		}
+
+		/* Write to the remote process */
+		printf("\t[+] Writing into the current process space at 0x%p\n", lpBaseAddress);
+		if (!WriteProcessMemory(hProcess, lpBaseAddress, lpDllPath, WriteBufferSize, NULL)) {
+			print_last_error(_T("WriteProcessMemory"));
+			break;
+		}
+
+		hThreadSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
+		if (hThreadSnapshot == INVALID_HANDLE_VALUE)
+			break;
+
+		THREADENTRY32 te32;
+		te32.dwSize = sizeof(THREADENTRY32);
+
+		//
+		// Brute force threads to find suitable alertable thread for APC injection (if any).
+		//
+		if (Thread32First(hThreadSnapshot, &te32)) {
+			do {
+				if (te32.th32OwnerProcessID == dwTargetProcessId) {
+
+					hThread = OpenThread(THREAD_ALL_ACCESS, FALSE, te32.th32ThreadID);
+					if (hThread) {
+
+						if (QueueUserAPC((PAPCFUNC)LoadLibraryAddress, hThread, (ULONG_PTR)lpBaseAddress)) {
+
+							if (IsDllInjected(dwTargetProcessId, lpDllName)) {
+								bStatus = TRUE;
+							}
+						}
+						CloseHandle(hThread);
+					}
+				}
+
+				// dll injected - leave
+				if (bStatus) {
+					_tprintf(_T("\t[+] Dll has been injected successfully ...\n"));
+					break;
+				}
+
+			} while (Thread32Next(hThreadSnapshot, &te32));
+		}
+
+	} while (FALSE); // not a loop
+
+	//
+	// Cleanup.
+	//
+	if (hThreadSnapshot != INVALID_HANDLE_VALUE) CloseHandle(hThreadSnapshot);
+
+	if (lpBaseAddress) {
+		VirtualFreeEx(hProcess, lpBaseAddress, 0, MEM_RELEASE);
 	}
 
-	/* Injection Happen here */
-	dResult = QueueUserAPC((PAPCFUNC)LoadLibraryAddress, hThread, (ULONG_PTR)lpBaseAddress);
-	if (dResult == NULL) {
-		print_last_error(_T("QueueUserAPC"));
-		return FALSE;
-	}
+	CloseHandle(hProcess);
 
-	else {
-		_tprintf(_T("Remote thread has been created successfully ...\n"));
-		WaitForSingleObject(hThread, INFINITE);
-
-		// Clean up
-		CloseHandle(hProcess);
-		CloseHandle(hThread);
-		VirtualFreeEx(hProcess, lpBaseAddress, dwSize, MEM_RELEASE);
-		return TRUE;
-	}
+	return bStatus;
 }

--- a/al-khaser/CodeInjection/RtlCreateUserThread.cpp
+++ b/al-khaser/CodeInjection/RtlCreateUserThread.cpp
@@ -31,7 +31,7 @@ BOOL RtlCreateUserThread_Injection()
 	dwProcessId = GetProcessIdFromName(_T("notepad.exe"));
 	if (dwProcessId == NULL)
 		return FALSE;
-	_tprintf(_T("\t[+] Getting proc id: %d\n"), dwProcessId);
+	_tprintf(_T("\t[+] Getting proc id: %u\n"), dwProcessId);
 
 	/* Obtain a handle the process */
 	hProcess = OpenProcess(PROCESS_ALL_ACCESS, FALSE, dwProcessId);

--- a/al-khaser/CodeInjection/SetWindowsHooksEx.cpp
+++ b/al-khaser/CodeInjection/SetWindowsHooksEx.cpp
@@ -15,13 +15,13 @@ BOOL SetWindowsHooksEx_Injection()
 	dwProcessId = GetProcessIdFromName(_T("notepad.exe"));
 	if (dwProcessId == NULL)
 		return FALSE;
-	_tprintf(_T("\t[+] Getting proc id: %d\n"), dwProcessId);
+	_tprintf(_T("\t[+] Getting proc id: %u\n"), dwProcessId);
 
 	/* Get thread id from process id */
 	dwThreadId = GetMainThreadId(dwProcessId);
 	if (dwThreadId == NULL)
 		return FALSE;
-	_tprintf(_T("\t[+] Getting main thread id of proc id: %d\n"), dwThreadId);
+	_tprintf(_T("\t[+] Getting main thread id of proc id: %u\n"), dwThreadId);
 
 	/* Get the full path of the dll to be injected */
 	GetFullPathName(lpDllName, MAX_PATH, lpDllPath, NULL);

--- a/al-khaser/Shared/Common.cpp
+++ b/al-khaser/Shared/Common.cpp
@@ -148,7 +148,7 @@ VOID print_last_error(LPCTSTR lpszFunction)
 
 		StringCchPrintf((LPTSTR)lpDisplayBuf,
 			LocalSize(lpDisplayBuf) / sizeof(TCHAR),
-			TEXT("%s failed with error %d: %s"),
+			TEXT("%s failed with error %u: %s"),
 			lpszFunction, dw, lpMsgBuf);
 
 		_tprintf((LPCTSTR)lpDisplayBuf);

--- a/al-khaser/Shared/Common.cpp
+++ b/al-khaser/Shared/Common.cpp
@@ -117,39 +117,47 @@ VOID print_os()
 	}
 }
 
-VOID print_last_error(LPCTSTR lpszFunction) 
-{ 
-    // Retrieve the system error message for the last-error code
+VOID print_last_error(LPCTSTR lpszFunction)
+{
+	// Retrieve the system error message for the last-error code
 
-    LPVOID lpMsgBuf;
-    LPVOID lpDisplayBuf;
-    DWORD dw = GetLastError(); 
+	LPVOID lpMsgBuf;
+	LPVOID lpDisplayBuf;
+	DWORD dw = GetLastError();
 
-    FormatMessage(			
-        FORMAT_MESSAGE_ALLOCATE_BUFFER | 
-        FORMAT_MESSAGE_FROM_SYSTEM |
-        FORMAT_MESSAGE_IGNORE_INSERTS,
-        NULL,
-        dw,
-        MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-        (LPTSTR) &lpMsgBuf,
-        0, NULL );
+	DWORD dwResult;
 
-    // Display the error message and exit the process
+	if (FormatMessage(
+		FORMAT_MESSAGE_ALLOCATE_BUFFER |
+		FORMAT_MESSAGE_FROM_SYSTEM |
+		FORMAT_MESSAGE_IGNORE_INSERTS,
+		NULL,
+		dw,
+		MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+		(LPTSTR)&lpMsgBuf,
+		0, NULL) == 0)
+	{
+		//FormatMessage failed, return
+		return;
+	}
 
-    lpDisplayBuf = (LPVOID)LocalAlloc(LMEM_ZEROINIT, 
-        (lstrlen((LPCTSTR)lpMsgBuf) + lstrlen((LPCTSTR)lpszFunction) + 40) * sizeof(TCHAR)); 
+	// Display the error message and exit the process
 
-    StringCchPrintf((LPTSTR)lpDisplayBuf, 
-        LocalSize(lpDisplayBuf) / sizeof(TCHAR),
-        TEXT("%s failed with error %d: %s"), 
-        lpszFunction, dw, lpMsgBuf); 
+	lpDisplayBuf = (LPVOID)LocalAlloc(LMEM_ZEROINIT,
+		(lstrlen((LPCTSTR)lpMsgBuf) + lstrlen((LPCTSTR)lpszFunction) + 40) * sizeof(TCHAR));
 
-	_tprintf((LPCTSTR)lpDisplayBuf); 
+	if (lpDisplayBuf) {
 
+		StringCchPrintf((LPTSTR)lpDisplayBuf,
+			LocalSize(lpDisplayBuf) / sizeof(TCHAR),
+			TEXT("%s failed with error %d: %s"),
+			lpszFunction, dw, lpMsgBuf);
 
-    LocalFree(lpMsgBuf);
-    LocalFree(lpDisplayBuf);
+		_tprintf((LPCTSTR)lpDisplayBuf);
+
+		LocalFree(lpDisplayBuf);
+	}
+	LocalFree(lpMsgBuf);
 }
 
 WCHAR* ascii_to_wide_str(CHAR* lpMultiByteStr)

--- a/al-khaser/Shared/Common.cpp
+++ b/al-khaser/Shared/Common.cpp
@@ -125,8 +125,6 @@ VOID print_last_error(LPCTSTR lpszFunction)
 	LPVOID lpDisplayBuf;
 	DWORD dw = GetLastError();
 
-	DWORD dwResult;
-
 	if (FormatMessage(
 		FORMAT_MESSAGE_ALLOCATE_BUFFER |
 		FORMAT_MESSAGE_FROM_SYSTEM |

--- a/al-khaser/Shared/Utils.cpp
+++ b/al-khaser/Shared/Utils.cpp
@@ -849,13 +849,18 @@ PBYTE get_system_firmware(_In_ DWORD signature, _In_ DWORD table, _Out_ PDWORD p
 	// if the buffer was too small, realloc and try again
 	if (resultBufferSize > bufferSize)
 	{
-		firmwareTable = static_cast<BYTE*>(realloc(firmwareTable, resultBufferSize));
-		SecureZeroMemory(firmwareTable, resultBufferSize);
-		if (GetSystemFirmwareTable(signature, table, firmwareTable, resultBufferSize) == 0)
-		{
-			printf("Second call failed :(\n");
-			free(firmwareTable);
-			return NULL;
+		PBYTE tmp;
+
+		tmp = static_cast<BYTE*>(realloc(firmwareTable, resultBufferSize));
+		if (tmp) {
+			firmwareTable = tmp;
+			SecureZeroMemory(firmwareTable, resultBufferSize);
+			if (GetSystemFirmwareTable(signature, table, firmwareTable, resultBufferSize) == 0)
+			{
+				printf("Second call failed :(\n");
+				free(firmwareTable);
+				return NULL;
+			}
 		}
 	}
 

--- a/al-khaser/Shared/Utils.cpp
+++ b/al-khaser/Shared/Utils.cpp
@@ -663,13 +663,19 @@ BOOL InitWMI(IWbemServices **pSvc, IWbemLocator **pLoc, const TCHAR* szNetworkRe
 		return 0;
 	}
 
-	// Connect to the root\cimv2 namespace 
-	hres = (*pLoc)->ConnectServer(BSTR(szNetworkResource), NULL, NULL, NULL, WBEM_FLAG_CONNECT_USE_MAX_WAIT, 0, 0, pSvc);
-	if (FAILED(hres)) {
-		print_last_error(_T("ConnectServer"));
-		(*pLoc)->Release();
-		CoUninitialize();
-		return 0;
+	BSTR strNetworkResource = SysAllocString(szNetworkResource);
+	if (strNetworkResource) {
+
+		// Connect to the root\cimv2 namespace 
+		hres = (*pLoc)->ConnectServer(strNetworkResource, NULL, NULL, NULL, WBEM_FLAG_CONNECT_USE_MAX_WAIT, 0, 0, pSvc);
+		if (FAILED(hres)) {
+			SysFreeString(strNetworkResource);
+			print_last_error(_T("ConnectServer"));
+			(*pLoc)->Release();
+			CoUninitialize();
+			return 0;
+		}
+		SysFreeString(strNetworkResource);
 	}
 
 	// Set security levels on the proxy -------------------------

--- a/al-khaser/Shared/Utils.cpp
+++ b/al-khaser/Shared/Utils.cpp
@@ -19,7 +19,7 @@ BOOL IsWoW64()
 
 BOOL Is_RegKeyValueExists(HKEY hKey, const TCHAR* lpSubKey, const TCHAR* lpValueName, const TCHAR* search_str)
 {
-	HKEY hkResult = FALSE;
+	HKEY hkResult = NULL;
 	TCHAR lpData[1024] = { 0 };
 	DWORD cbData = MAX_PATH;
 
@@ -41,7 +41,7 @@ BOOL Is_RegKeyValueExists(HKEY hKey, const TCHAR* lpSubKey, const TCHAR* lpValue
 
 BOOL Is_RegKeyExists(HKEY hKey, const TCHAR* lpSubKey)
 {
-	HKEY hkResult = FALSE;
+	HKEY hkResult = NULL;
 	TCHAR lpData[1024] = { 0 };
 	DWORD cbData = MAX_PATH;
 
@@ -403,7 +403,7 @@ BOOL GetOSDisplayString(LPTSTR pszOS)
 
 		TCHAR buf[80];
 
-		StringCchPrintf(buf, 80, TEXT(" (build %d)"), osvi.dwBuildNumber);
+		StringCchPrintf(buf, 80, TEXT(" (build %u)"), osvi.dwBuildNumber);
 		StringCchCat(pszOS, MAX_PATH, buf);
 
 		if (osvi.dwMajorVersion >= 6)
@@ -901,7 +901,7 @@ bool attempt_to_read_memory_wow64(PVOID buffer, DWORD size, PVOID64 address)
 		return status == 0;
 	}
 
-	printf("attempt_to_read_memory_wow64: Couldn't open process: %d\n", GetLastError());
+	printf("attempt_to_read_memory_wow64: Couldn't open process: %u\n", GetLastError());
 	return false;
 }
 

--- a/al-khaser/Shared/log.cpp
+++ b/al-khaser/Shared/log.cpp
@@ -1,7 +1,6 @@
 #include "pch.h"
 #include "log.h"
 
-FILE *fp;
 static int SESSION_TRACKER; //Keeps track of session
 
 TCHAR* print_time()
@@ -47,12 +46,19 @@ void log_print(const TCHAR* filename, const TCHAR *fmt, ...)
 	const TCHAR *p, *r;
 	int e;
 
+	FILE *fp = NULL;
+	errno_t error;
+
 	TCHAR *pszTime;
 
 	if (SESSION_TRACKER > 0)
-		_tfopen_s(&fp, _T("log.txt"), _T("a+"));
+		error = _tfopen_s(&fp, _T("log.txt"), _T("a+"));
 	else
-		_tfopen_s(&fp, _T("log.txt"), _T("w"));
+		error = _tfopen_s(&fp, _T("log.txt"), _T("w"));
+
+	// file create/open failed
+	if ((error != 0) || (fp == NULL))
+		return;
 
 	pszTime = print_time();
 	if (pszTime) {

--- a/al-khaser/TimingAttacks/timing.cpp
+++ b/al-khaser/TimingAttacks/timing.cpp
@@ -232,7 +232,10 @@ BOOL timing_IcmpSendEcho(UINT delayInMillis)
 		return TRUE;
 	}
 
-	ReplySize = sizeof(ICMP_ECHO_REPLY) + sizeof(SendData);
+	//
+	// Size of ICMP_ECHO_REPLY + size of send data + 8 extra bytes for ICMP error message
+	//
+	ReplySize = sizeof(ICMP_ECHO_REPLY) + sizeof(SendData) + 8;
 	ReplyBuffer = (VOID*)malloc(ReplySize);
 	if (ReplyBuffer == NULL) {
 		IcmpCloseHandle(hIcmpFile);
@@ -252,29 +255,37 @@ Timing attack using waitable timers. Test fails if any of the calls return an er
 */
 BOOL timing_CreateWaitableTimer(UINT delayInMillis)
 {
-	HANDLE hTimer = NULL;
+	HANDLE hTimer;
 	LARGE_INTEGER dueTime;
+
+	BOOL bResult = FALSE;
+
 	dueTime.QuadPart = delayInMillis * -10000LL;
+	
 	hTimer = CreateWaitableTimer(NULL, TRUE, NULL);
-	if (hTimer == INVALID_HANDLE_VALUE)
+	
+	if (hTimer == NULL)
 	{
 		return TRUE;
 	}
+
 	if (SetWaitableTimer(hTimer, &dueTime, 0, NULL, NULL, FALSE) == FALSE)
 	{
-		return TRUE;
+		bResult = TRUE;
 	}
-	if (WaitForSingleObject(hTimer, INFINITE) != WAIT_OBJECT_0)
-	{
-		return TRUE;
+	else {
+		if (WaitForSingleObject(hTimer, INFINITE) != WAIT_OBJECT_0)
+		{
+			bResult = TRUE;
+		}
 	}
 
 	CancelWaitableTimer(hTimer);
 	CloseHandle(hTimer);
-	return FALSE;
+	return bResult;
 }
 
-HANDLE hEventCTQT = NULL;
+HANDLE g_hEventCTQT = NULL;
 
 /*
 Timing attack using CreateTimerQueueTimer. Test fails if any of the calls return an error state.
@@ -282,9 +293,12 @@ Timing attack using CreateTimerQueueTimer. Test fails if any of the calls return
 BOOL timing_CreateTimerQueueTimer(UINT delayInMillis)
 {
 	HANDLE hTimerQueue;
-	HANDLE hTimerQueueTimer;
+	HANDLE hTimerQueueTimer = NULL;
+	BOOL bResult = FALSE;
 
-	hEventCTQT = CreateEvent(NULL, FALSE, FALSE, NULL);
+	g_hEventCTQT = CreateEvent(NULL, FALSE, FALSE, NULL);
+	if (g_hEventCTQT == NULL)
+		return FALSE;
 
 	hTimerQueue = CreateTimerQueue();
 	if (hTimerQueue == NULL)
@@ -301,27 +315,31 @@ BOOL timing_CreateTimerQueueTimer(UINT delayInMillis)
 		0,
 		WT_EXECUTEDEFAULT) == FALSE)
 	{
-		return TRUE;
+		bResult = TRUE;
+	}
+	else {
+
+		// idea here is to wait only 10x the expected delay time
+		// if the wait expires before the timer comes back, we fail the test
+		if (WaitForSingleObject(g_hEventCTQT, delayInMillis * 10) != WAIT_OBJECT_0)
+		{
+			bResult = FALSE;
+		}
+
 	}
 
-	// idea here is to wait only 10x the expected delay time
-	// if the wait expires before the timer comes back, we fail the test
-	if (WaitForSingleObject(hEventCTQT, delayInMillis * 10) != WAIT_OBJECT_0)
-	{
-		return FALSE;
-	}
+	// Delete all timers in the timer queue.
+	DeleteTimerQueueEx(hTimerQueue, NULL);
 
-	CloseHandle(hEventCTQT);
-	CloseHandle(hTimerQueueTimer);
-	CloseHandle(hTimerQueue);
+	CloseHandle(g_hEventCTQT);
 
-	return FALSE;
+	return bResult;
 }
 
 VOID CALLBACK CallbackCTQT(PVOID lParam, BOOLEAN TimerOrWaitFired)
 {
 	if (TimerOrWaitFired == TRUE && lParam == reinterpret_cast<PVOID>(0xDEADBEEFULL))
 	{
-		SetEvent(hEventCTQT);
+		SetEvent(g_hEventCTQT);
 	}
 }

--- a/al-khaser/TimingAttacks/timing.cpp
+++ b/al-khaser/TimingAttacks/timing.cpp
@@ -228,18 +228,21 @@ BOOL timing_IcmpSendEcho(UINT delayInMillis)
 	hIcmpFile = IcmpCreateFile();
 	if (hIcmpFile == INVALID_HANDLE_VALUE) {
 		printf("\tUnable to open handle.\n");
-		printf("IcmpCreatefile returned error: %ld\n", GetLastError());
+		printf("IcmpCreatefile returned error: %u\n", GetLastError());
 		return TRUE;
 	}
 
 	ReplySize = sizeof(ICMP_ECHO_REPLY) + sizeof(SendData);
 	ReplyBuffer = (VOID*)malloc(ReplySize);
 	if (ReplyBuffer == NULL) {
+		IcmpCloseHandle(hIcmpFile);
 		printf("\tUnable to allocate memory\n");
 		return TRUE;
 	}
 
 	IcmpSendEcho(hIcmpFile, DestinationAddress, SendData, sizeof(SendData), NULL, ReplyBuffer, ReplySize, delayInMillis);
+	IcmpCloseHandle(hIcmpFile);
+	free(ReplyBuffer);
 
 	return FALSE;
 }


### PR DESCRIPTION
Fix for HardwareBreakpoints routine
Update process.cpp
Fix multiple bugs in WMI related routines
Fix memory leak in check_mac_addr routine
Update MemoryBreakpoints_PageGuard.cpp
Fix multiple bugs in ScanForModules.cpp
Fix bug in IsBadLibrary
Fix number of bugs in get_system_firmware
Fix InitWMI routine
Update IsBadLibrary 
Remove incorrect result checks and wrong printf specifiers in ScanForModules.cpp
Fix null pointer dereference in qemu_firmware_ACPI routine
Fix null pointer dereferences in VirtualBox.cpp & VMWare.cpp
Fix QueueUserAPC_Injection routine by rewrite
Fix null pointer dereference in setupdi_diskdrive routine
Add error handling in log_print
Fix null pointer dereference in print_last_error routine, add more error handling
Fixes in Services.cpp
Fix signed/unsigned mismatch for specifiers in various *printf calls
Fix resource leak in timing_IcmpSendEcho routine
Fix missing VirtualAlloc checks in WriteWatch.cpp
Fix number of bugs in timing.cpp
Remove incorrect return value checks

Please review these changes because they affect all WMI related parts of your program. I tried not to screw up something but more eyes is better.

P.S.
According to ScanForModules unit. Despite patches the code for mapped/hidden modules enumeration is a mess, very slow because of ineffectiveness and bugged, I can only suggest to rewrite it from the scratch completely.