### PR TITLE
Crash fix for 32 bit app running on Win7 x64

### DIFF
--- a/al-khaser/AntiDebug/ScanForModules.cpp
+++ b/al-khaser/AntiDebug/ScanForModules.cpp
@@ -479,10 +479,10 @@ BOOL ScanForModules_LDR_Direct()
 
 			if (IsWoW64())
 			{
-				PPEB64 peb = reinterpret_cast<PPEB64>(reinterpret_cast<UCHAR*>(pbi.PebBaseAddress) - 0x1000);
+				PPEB64 peb64 = reinterpret_cast<PPEB64>(GetPeb64());
 				PEB_LDR_DATA64 ldrData = { 0 };
-
-				if (attempt_to_read_memory_wow64(&ldrData, sizeof(PEB_LDR_DATA64), peb->Ldr))
+				
+				if (peb64 && attempt_to_read_memory_wow64(&ldrData, sizeof(PEB_LDR_DATA64), peb64->Ldr))
 				{
 					auto ldrEntries = WalkLDR(&ldrData);
 					for (LDR_DATA_TABLE_ENTRY64* ldrEntry : *ldrEntries)

--- a/al-khaser/AntiDebug/ScanForModules.cpp
+++ b/al-khaser/AntiDebug/ScanForModules.cpp
@@ -97,6 +97,14 @@ bool IsBadLibrary(TCHAR* filename, DWORD filenameLength)
 
 	GetSystemDirectory(systemRootPath, MAX_PATH);
 
+#ifdef _X86_
+	TCHAR syswow64Path[MAX_PATH];
+	SHGetFolderPath (NULL, CSIDL_SYSTEMX86, NULL, 0, syswow64Path);
+	StringCbCat(syswow64Path, MAX_PATH, _T("\\"));
+	size_t syswow64PathLength = 0;
+	StringCbLength(syswow64Path, MAX_PATH, &syswow64PathLength);
+#endif
+
 	size_t exePathLength = GetProcessImageFileName(GetCurrentProcess(), exePath, MAX_PATH);
 	NormalizeNTPath(exePath, MAX_PATH);
 	StringCbLength(exePath, MAX_PATH, &exePathLength);
@@ -129,6 +137,14 @@ bool IsBadLibrary(TCHAR* filename, DWORD filenameLength)
 				// path matched the regular system path
 				return false;
 			}
+
+#ifdef _X86_
+			if (IsWoW64() && StrNCmpI(syswow64Path, normalisedPath, (int)(min(syswow64PathLength, normalisedPathLength) / sizeof(TCHAR)) ) == 0)
+			{
+				// path matched the wow64 system path
+				return false;
+			}
+#endif
 
 			if (StrCmpI(exePath, normalisedPath) == 0)
 			{

--- a/al-khaser/Shared/APIs.cpp
+++ b/al-khaser/Shared/APIs.cpp
@@ -4,31 +4,32 @@
 #define API_COUNT (sizeof(ApiData)/sizeof(*ApiData))
 
 API_DATA ApiData[] = {
-	/*                Identifier                        Library             Export Name                     X86/X64/either			Minimum OS Version              Removed in OS Version   */
-	{ API_IDENTIFIER::API_CsrGetProcessId,				"ntdll.dll",		"CsrGetProcessId",				API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP,			API_OS_VERSION::NONE },
-	{ API_IDENTIFIER::API_EnumSystemFirmwareTables,		"kernel32.dll",		"EnumSystemFirmwareTables",		API_OS_BITS::ANY,		API_OS_VERSION::WIN_VISTA,		API_OS_VERSION::NONE },
-	{ API_IDENTIFIER::API_GetNativeSystemInfo,			"kernel32.dll",		"GetNativeSystemInfo",			API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP,			API_OS_VERSION::NONE },
-	{ API_IDENTIFIER::API_GetProductInfo,				"kernel32.dll",		"GetProductInfo",				API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP,			API_OS_VERSION::NONE },
-	{ API_IDENTIFIER::API_GetSystemFirmwareTable,		"kernel32.dll",		"GetSystemFirmwareTable",		API_OS_BITS::ANY,		API_OS_VERSION::WIN_VISTA,		API_OS_VERSION::NONE },
-	{ API_IDENTIFIER::API_IsWow64Process,				"kernel32.dll",		"IsWow64Process",				API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP_SP2,		API_OS_VERSION::NONE },
-	{ API_IDENTIFIER::API_LdrEnumerateLoadedModules,	"ntdll.dll",		"LdrEnumerateLoadedModules",	API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP_SP1,		API_OS_VERSION::NONE },
-	{ API_IDENTIFIER::API_NtClose,						"ntdll.dll",		"NtClose",						API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP,			API_OS_VERSION::NONE },
-	{ API_IDENTIFIER::API_NtCreateDebugObject,			"ntdll.dll",		"NtCreateDebugObject",			API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP,			API_OS_VERSION::NONE },
-	{ API_IDENTIFIER::API_NtDelayExecution,				"ntdll.dll",		"NtDelayExecution",				API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP,			API_OS_VERSION::NONE },
-	{ API_IDENTIFIER::API_NtQueryInformationThread,		"ntdll.dll",		"NtQueryInformationThread",		API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP,			API_OS_VERSION::NONE },
-	{ API_IDENTIFIER::API_NtQueryInformationProcess,	"ntdll.dll",		"NtQueryInformationProcess",	API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP,			API_OS_VERSION::NONE },
-	{ API_IDENTIFIER::API_NtQueryObject,				"ntdll.dll",		"NtQueryObject",				API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP,			API_OS_VERSION::NONE },
-	{ API_IDENTIFIER::API_NtQuerySystemInformation,		"ntdll.dll",		"NtQuerySystemInformation",		API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP,			API_OS_VERSION::NONE },
-	{ API_IDENTIFIER::API_NtSetInformationThread,		"ntdll.dll",		"NtSetInformationThread",		API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP,			API_OS_VERSION::NONE },
-	{ API_IDENTIFIER::API_NtWow64ReadVirtualMemory64,	"ntdll.dll",		"NtWow64ReadVirtualMemory64",	API_OS_BITS::X86_ONLY,	API_OS_VERSION::WIN_XP_SP1,		API_OS_VERSION::NONE },
-	{ API_IDENTIFIER::API_NtWow64QueryVirtualMemory64,	"ntdll.dll",		"NtWow64QueryVirtualMemory64",	API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP_SP1,		API_OS_VERSION::WIN_10 },
-	{ API_IDENTIFIER::API_NtYieldExecution,				"ntdll.dll",		"NtYieldExecution",				API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP,			API_OS_VERSION::NONE },
-	{ API_IDENTIFIER::API_RtlGetVersion,				"ntdll.dll",		"RtlGetVersion",				API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP,			API_OS_VERSION::NONE },
-	{ API_IDENTIFIER::API_WudfIsAnyDebuggerPresent,		"WUDFPlatform.dll",	"WudfIsAnyDebuggerPresent",		API_OS_BITS::X64_ONLY,	API_OS_VERSION::WIN_VISTA,		API_OS_VERSION::NONE },
-	{ API_IDENTIFIER::API_WudfIsKernelDebuggerPresent,	"WUDFPlatform.dll",	"WudfIsKernelDebuggerPresent",	API_OS_BITS::X64_ONLY,	API_OS_VERSION::WIN_VISTA,		API_OS_VERSION::NONE },
-	{ API_IDENTIFIER::API_WudfIsUserDebuggerPresent,	"WUDFPlatform.dll",	"WudfIsUserDebuggerPresent",	API_OS_BITS::X64_ONLY,	API_OS_VERSION::WIN_VISTA,		API_OS_VERSION::NONE },
-	{ API_IDENTIFIER::API_NtQueryLicenseValue,			"ntdll.dll",		"NtQueryLicenseValue",			API_OS_BITS::ANY,		API_OS_VERSION::WIN_VISTA,		API_OS_VERSION::NONE },
-	{ API_IDENTIFIER::API_RtlInitUnicodeString,			"ntdll.dll",		"RtlInitUnicodeString",			API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP,			API_OS_VERSION::NONE }
+	/*                Identifier                            Library             Export Name                         X86/X64/either			Minimum OS Version              Removed in OS Version   */
+	{ API_IDENTIFIER::API_CsrGetProcessId,				    "ntdll.dll",		"CsrGetProcessId",				    API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP,			API_OS_VERSION::NONE },
+	{ API_IDENTIFIER::API_EnumSystemFirmwareTables,		    "kernel32.dll",		"EnumSystemFirmwareTables",		    API_OS_BITS::ANY,		API_OS_VERSION::WIN_VISTA,		API_OS_VERSION::NONE },
+	{ API_IDENTIFIER::API_GetNativeSystemInfo,			    "kernel32.dll",		"GetNativeSystemInfo",		    	API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP,			API_OS_VERSION::NONE },
+	{ API_IDENTIFIER::API_GetProductInfo,				    "kernel32.dll",		"GetProductInfo",				    API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP,			API_OS_VERSION::NONE },
+	{ API_IDENTIFIER::API_GetSystemFirmwareTable,		    "kernel32.dll",		"GetSystemFirmwareTable",	    	API_OS_BITS::ANY,		API_OS_VERSION::WIN_VISTA,		API_OS_VERSION::NONE },
+	{ API_IDENTIFIER::API_IsWow64Process,				    "kernel32.dll",		"IsWow64Process",			    	API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP_SP2,		API_OS_VERSION::NONE },
+	{ API_IDENTIFIER::API_LdrEnumerateLoadedModules,	    "ntdll.dll",		"LdrEnumerateLoadedModules",    	API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP_SP1,		API_OS_VERSION::NONE },
+	{ API_IDENTIFIER::API_NtClose,						    "ntdll.dll",		"NtClose",					    	API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP,			API_OS_VERSION::NONE },
+	{ API_IDENTIFIER::API_NtCreateDebugObject,			    "ntdll.dll",		"NtCreateDebugObject",		    	API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP,			API_OS_VERSION::NONE },
+	{ API_IDENTIFIER::API_NtDelayExecution,				    "ntdll.dll",		"NtDelayExecution",			    	API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP,			API_OS_VERSION::NONE },
+	{ API_IDENTIFIER::API_NtQueryInformationThread,		    "ntdll.dll",		"NtQueryInformationThread",	    	API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP,			API_OS_VERSION::NONE },
+	{ API_IDENTIFIER::API_NtQueryInformationProcess,	    "ntdll.dll",		"NtQueryInformationProcess",	    API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP,			API_OS_VERSION::NONE },
+	{ API_IDENTIFIER::API_NtQueryObject,				    "ntdll.dll",		"NtQueryObject",				    API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP,			API_OS_VERSION::NONE },
+	{ API_IDENTIFIER::API_NtQuerySystemInformation,		    "ntdll.dll",		"NtQuerySystemInformation",		    API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP,			API_OS_VERSION::NONE },
+	{ API_IDENTIFIER::API_NtSetInformationThread,		    "ntdll.dll",		"NtSetInformationThread",		    API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP,			API_OS_VERSION::NONE },
+	{ API_IDENTIFIER::API_NtWow64QueryInformationProcess64, "ntdll.dll",        "NtWow64QueryInformationProcess64",	API_OS_BITS::X86_ONLY,	API_OS_VERSION::WIN_XP_SP1,		API_OS_VERSION::NONE },
+	{ API_IDENTIFIER::API_NtWow64ReadVirtualMemory64,	    "ntdll.dll",		"NtWow64ReadVirtualMemory64",	    API_OS_BITS::X86_ONLY,	API_OS_VERSION::WIN_XP_SP1,		API_OS_VERSION::NONE },
+	{ API_IDENTIFIER::API_NtWow64QueryVirtualMemory64,	    "ntdll.dll",		"NtWow64QueryVirtualMemory64",	    API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP_SP1,		API_OS_VERSION::WIN_10 },
+	{ API_IDENTIFIER::API_NtYieldExecution,			    	"ntdll.dll",		"NtYieldExecution",			    	API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP,			API_OS_VERSION::NONE },
+	{ API_IDENTIFIER::API_RtlGetVersion,		    		"ntdll.dll",		"RtlGetVersion",		    		API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP,			API_OS_VERSION::NONE },
+	{ API_IDENTIFIER::API_WudfIsAnyDebuggerPresent,	    	"WUDFPlatform.dll",	"WudfIsAnyDebuggerPresent",	    	API_OS_BITS::X64_ONLY,	API_OS_VERSION::WIN_VISTA,		API_OS_VERSION::NONE },
+	{ API_IDENTIFIER::API_WudfIsKernelDebuggerPresent,	    "WUDFPlatform.dll",	"WudfIsKernelDebuggerPresent",	    API_OS_BITS::X64_ONLY,	API_OS_VERSION::WIN_VISTA,		API_OS_VERSION::NONE },
+	{ API_IDENTIFIER::API_WudfIsUserDebuggerPresent,	    "WUDFPlatform.dll",	"WudfIsUserDebuggerPresent",    	API_OS_BITS::X64_ONLY,	API_OS_VERSION::WIN_VISTA,		API_OS_VERSION::NONE },
+	{ API_IDENTIFIER::API_NtQueryLicenseValue,			    "ntdll.dll",		"NtQueryLicenseValue",	    		API_OS_BITS::ANY,		API_OS_VERSION::WIN_VISTA,		API_OS_VERSION::NONE },
+	{ API_IDENTIFIER::API_RtlInitUnicodeString,			    "ntdll.dll",		"RtlInitUnicodeString",		    	API_OS_BITS::ANY,		API_OS_VERSION::WIN_XP,			API_OS_VERSION::NONE }
 };
 
 void API::Init()

--- a/al-khaser/Shared/APIs.h
+++ b/al-khaser/Shared/APIs.h
@@ -17,6 +17,7 @@ enum API_IDENTIFIER
 	API_NtQueryObject,
 	API_NtQuerySystemInformation,
 	API_NtSetInformationThread,
+	API_NtWow64QueryInformationProcess64,
 	API_NtWow64QueryVirtualMemory64,
 	API_NtWow64ReadVirtualMemory64,
 	API_NtYieldExecution,

--- a/al-khaser/Shared/ApiTypeDefs.h
+++ b/al-khaser/Shared/ApiTypeDefs.h
@@ -55,6 +55,12 @@ typedef NTSTATUS(WINAPI* pNtUnmapViewOfSection)(HANDLE ProcessHandle, PVOID Base
 typedef NTSTATUS(WINAPI* pNtYieldExecution)();
 typedef NTSTATUS(WINAPI* pRtlGetVersion)(RTL_OSVERSIONINFOEXW*);
 typedef ULONG (NTAPI* pRtlNtStatusToDosError)(IN NTSTATUS Status);
+typedef NTSTATUS(NTAPI * pNtWow64QueryInformationProcess64)(
+    IN HANDLE ProcessHandle,
+    ULONG ProcessInformationClass,
+    OUT PVOID ProcessInformation,
+    IN ULONG ProcessInformationLength,
+    OUT PULONG ReturnLength OPTIONAL);
 typedef NTSTATUS(WINAPI *pNtWow64ReadVirtualMemory64)(
 	HANDLE ProcessHandle,
 	PVOID64 BaseAddress,

--- a/al-khaser/Shared/Utils.cpp
+++ b/al-khaser/Shared/Utils.cpp
@@ -17,6 +17,23 @@ BOOL IsWoW64()
 	return bIsWow64;
 }
 
+PVOID64 GetPeb64()
+{
+	PVOID64 peb64 = NULL;
+
+	if (API::IsAvailable(API_IDENTIFIER::API_NtWow64QueryInformationProcess64))
+	{
+		PROCESS_BASIC_INFORMATION_WOW64 pbi64 = {};
+
+		auto NtWow64QueryInformationProcess64 = static_cast<pNtWow64QueryInformationProcess64>(API::GetAPI(API_IDENTIFIER::API_NtWow64QueryInformationProcess64));
+		NTSTATUS status = NtWow64QueryInformationProcess64(GetCurrentProcess(), ProcessBasicInformation, &pbi64, sizeof(pbi64), nullptr);
+		if ( NT_SUCCESS ( status ) )
+			peb64 = pbi64.PebBaseAddress;
+	}
+
+	return peb64;
+}
+
 BOOL Is_RegKeyValueExists(HKEY hKey, const TCHAR* lpSubKey, const TCHAR* lpValueName, const TCHAR* search_str)
 {
 	HKEY hkResult = NULL;

--- a/al-khaser/Shared/Utils.h
+++ b/al-khaser/Shared/Utils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 BOOL IsWoW64();
+PVOID64 GetPeb64();
 BOOL Is_RegKeyValueExists(HKEY hKey, const TCHAR* lpSubKey, const TCHAR* lpValueName, const TCHAR* search_str);
 BOOL Is_RegKeyExists(HKEY hKey, const TCHAR* lpSubKey);
 BOOL is_FileExists(TCHAR* szPath);

--- a/al-khaser/Shared/WinStructs.h
+++ b/al-khaser/Shared/WinStructs.h
@@ -27,6 +27,14 @@ typedef struct _THREAD_BASIC_INFORMATION {
 	KPRIORITY               BasePriority;
 } THREAD_BASIC_INFORMATION, *PTHREAD_BASIC_INFORMATION;
 
+typedef struct _PROCESS_BASIC_INFORMATION_WOW64 {
+	PVOID Reserved1[2];
+	PVOID64 PebBaseAddress;
+	PVOID Reserved2[4];
+	ULONG_PTR UniqueProcessId[2];
+	PVOID Reserved3[2];
+} PROCESS_BASIC_INFORMATION_WOW64;
+
 typedef struct _PEB64 {
 	BYTE Reserved1[2];
 	BYTE BeingDebugged;


### PR DESCRIPTION
Due to incorrect PEB64 address: on both systems distance between addresses of native and wow64 PEB's is one page ( 0x1000 ), but the order is different.