### PR TITLE
Fix VARIANT vartype flags check on WMI properties

### DIFF
--- a/al-khaser/AntiVM/VirtualBox.cpp
+++ b/al-khaser/AntiVM/VirtualBox.cpp
@@ -261,7 +261,7 @@ BOOL vbox_mac_wmi()
 
 					if (V_VT(&vtProp) != VT_NULL) {
 
-						if (vtProp.vt | VT_BSTR == VT_BSTR)
+						if ((vtProp.vt & VT_BSTR) == VT_BSTR)
 						{
 							// Do our comparison
 							if (_tcsstr(vtProp.bstrVal, _T("08:00:27")) != 0) {
@@ -336,7 +336,7 @@ BOOL vbox_eventlogfile_wmi()
 				hRes = pclsObj->Get(_T("FileName"), 0, &vtProp, 0, 0);
 				if (SUCCEEDED(hRes) && (V_VT(&vtProp) != VT_NULL)) {
 
-					if (vtProp.vt | VT_BSTR == VT_BSTR)
+					if ((vtProp.vt & VT_BSTR) == VT_BSTR)
 					{
 						// Do our comparaison
 						if (StrCmpI(vtProp.bstrVal, _T("System")) == 0) {
@@ -586,7 +586,7 @@ BOOL vbox_pnpentity_controllers_wmi()
 
 					if (V_VT(&vtProp) != VT_NULL) {
 
-						if (vtProp.vt | VT_BSTR == VT_BSTR)
+						if ((vtProp.vt & VT_BSTR) == VT_BSTR)
 						{
 							// increment the find counter if this instance matches any of the known VBox hardware
 							if (_tcsstr(vtProp.bstrVal, _T("82801FB")) != 0) {
@@ -671,7 +671,7 @@ BOOL vbox_bus_wmi()
 
 					if (V_VT(&vtProp) != VT_NULL)
 					{
-						if (vtProp.vt | VT_BSTR == VT_BSTR)
+						if ((vtProp.vt & VT_BSTR) == VT_BSTR)
 						{
 							// increment the find counter if this is 
 							if (_tcsstr(vtProp.bstrVal, _T("ACPIBus_BUS_0")) != 0) {
@@ -749,7 +749,7 @@ BOOL vbox_baseboard_wmi()
 
 					if (V_VT(&vtProp) != VT_NULL) {
 
-						if (vtProp.vt | VT_BSTR == VT_BSTR)
+						if ((vtProp.vt & VT_BSTR) == VT_BSTR)
 						{
 							// Do our comparison
 							if (_tcsstr(vtProp.bstrVal, _T("VirtualBox")) != 0) {
@@ -770,7 +770,7 @@ BOOL vbox_baseboard_wmi()
 
 					if (V_VT(&vtProp) != VT_NULL) {
 
-						if (vtProp.vt | VT_BSTR == VT_BSTR)
+						if ((vtProp.vt & VT_BSTR) == VT_BSTR)
 						{
 							// Do our comparison
 							if (_tcsstr(vtProp.bstrVal, _T("Oracle Corporation")) != 0) {
@@ -840,7 +840,7 @@ BOOL vbox_pnpentity_vboxname_wmi()
 
 					if (V_VT(&vtProp) != VT_NULL) {
 
-						if (vtProp.vt | VT_BSTR == VT_BSTR)
+						if ((vtProp.vt & VT_BSTR) == VT_BSTR)
 						{
 							// Do our comparison
 							if (_tcsstr(vtProp.bstrVal, _T("VBOX")) != 0) {
@@ -859,7 +859,7 @@ BOOL vbox_pnpentity_vboxname_wmi()
 
 					if (V_VT(&vtProp) != VT_NULL) {
 
-						if (vtProp.vt | VT_BSTR == VT_BSTR)
+						if ((vtProp.vt & VT_BSTR) == VT_BSTR)
 						{
 							// Do our comparison
 							if (_tcsstr(vtProp.bstrVal, _T("VBOX")) != 0) {
@@ -878,7 +878,7 @@ BOOL vbox_pnpentity_vboxname_wmi()
 
 					if (V_VT(&vtProp) != VT_NULL) {
 
-						if (vtProp.vt | VT_BSTR == VT_BSTR)
+						if ((vtProp.vt & VT_BSTR) == VT_BSTR)
 						{
 							// Do our comparison
 							if (_tcsstr(vtProp.bstrVal, _T("VEN_VBOX")) != 0) {


### PR DESCRIPTION
The check to see if a property is a `VT_BSTR` should be done with AND, not OR.

I found this because my compiler complained about these lines with:
`warning C4554: '|': check operator precedence for possible error; use parentheses to clarify precedence`. So I added parentheses to silence the warning as well.