### PR TITLE
Anti-dump: fix SizeOfImage() modifying the wrong module and field

### DIFF
--- a/al-khaser/AntiDump/SizeOfImage.cpp
+++ b/al-khaser/AntiDump/SizeOfImage.cpp
@@ -14,6 +14,10 @@ VOID SizeOfImage()
 #endif
 
 	_tprintf(_T("[*] Increasing SizeOfImage in PE Header to: 0x100000\n"));
-	PLDR_DATA_TABLE_ENTRY tableEntry = (PLDR_DATA_TABLE_ENTRY)(pPeb->Ldr->InMemoryOrderModuleList.Flink);
-	tableEntry->DllBase = (PVOID)((INT_PTR)tableEntry->DllBase + 0x100000);
+
+	// The following pointer hackery is because winternl.h defines incomplete PEB types
+	PLIST_ENTRY InLoadOrderModuleList = (PLIST_ENTRY)pPeb->Ldr->Reserved2[1]; // pPeb->Ldr->InLoadOrderModuleList
+	PLDR_DATA_TABLE_ENTRY tableEntry = CONTAINING_RECORD(InLoadOrderModuleList, LDR_DATA_TABLE_ENTRY, Reserved1[0] /*InLoadOrderLinks*/);
+	PULONG pEntrySizeOfImage = (PULONG)&tableEntry->Reserved3[1]; // &tableEntry->SizeOfImage
+	*pEntrySizeOfImage = (ULONG)((INT_PTR)tableEntry->DllBase + 0x100000);
 }


### PR DESCRIPTION
`SizeOfImage()` is supposed to increase the reported size of the EXE in the loader module list. However it was writing the new size value to the `DllBase` field instead of `SizeOfImage`.

Additionally, the function was using `InMemoryOrderModuleList` to find the EXE, but due to this list being in memory order as the name implies, it usually actually modified the wrong module. I changed this to use `InLoadOrderModuleList` instead, in which the EXE is always the first entry.

While this code works, it does contain some ugly pointer hackery which is needed because `winternl.h` is woefully inadequate and doesn't define the needed fields. I added comments for clarification of the fields, but if this is not enough I suggest replacing `winternl.h` with a header(s) containing the uncensored types such as the Process Hacker SDK or `ntdll.h` from ScyllaHide.