### PR TITLE
DebugObjectHandle improvements

### DIFF
--- a/al-khaser/AntiDebug/NtQueryInformationProcess_ProcessDebugObject.cpp
+++ b/al-khaser/AntiDebug/NtQueryInformationProcess_ProcessDebugObject.cpp
@@ -10,14 +10,14 @@ the process isn't being debugged
 
 BOOL NtQueryInformationProcess_ProcessDebugObject()
 {
-	// ProcessDebugFlags
+	// ProcessDebugObjectHandle
 	const int ProcessDebugObjectHandle =  0x1e;
 
 	auto NtQueryInfoProcess = static_cast<pNtQueryInformationProcess>(API::GetAPI(API_IDENTIFIER::API_NtQueryInformationProcess));
 
 	// Other Vars
 	NTSTATUS Status;
-	HANDLE hDebugObject = NULL; 
+	HANDLE hDebugObject = NULL;
 
 #if defined (ENV64BIT)
 	DWORD dProcessInformationLength = sizeof(ULONG) * 2;
@@ -29,9 +29,11 @@ BOOL NtQueryInformationProcess_ProcessDebugObject()
 #endif
 
 	Status = NtQueryInfoProcess(GetCurrentProcess(), ProcessDebugObjectHandle, &hDebugObject, dProcessInformationLength, NULL);
-    
-	if (Status == 0x00000000 && hDebugObject)
-        return TRUE;
-    else
-        return FALSE;
+
+	if (Status != STATUS_PORT_NOT_SET)
+		return TRUE;
+	if (hDebugObject != NULL)
+		return TRUE;
+
+	return FALSE;
 }

--- a/al-khaser/AntiDebug/NtQueryInformationProcess_ProcessDebugObject.h
+++ b/al-khaser/AntiDebug/NtQueryInformationProcess_ProcessDebugObject.h
@@ -1,3 +1,5 @@
 #pragma once
 
 BOOL NtQueryInformationProcess_ProcessDebugObject();
+
+#define STATUS_PORT_NOT_SET ((NTSTATUS)0xC0000353L)


### PR DESCRIPTION
This PR makes two changes to the DebugObjectHandle check:
- The return status must now be `STATUS_PORT_NOT_SET`. Any other status is a failure. This addresses #195.
- A second call to `NtQueryInformationProcess` has been added with the debug object handle and return length buffers overlapping. The idea is that this will catch anti-anti-debuggers making use of logic similar to the following:
    ```
    // ...call original NtQueryInformationProcess here...
    *(HANDLE*)ProcessInformation = NULL;
    return STATUS_PORT_NOT_SET;
    ```
    The check will now catch this because the combined handle/return length is incorrectly set to `NULL` in the above example, overwriting the real return length. The reason `sizeof(HANDLE)` is the correct value of the overlapping buffer is because the kernel writes the return length last.