### PR TITLE
Use Wow64DisableWow64FsRedirection/Wow64RevertWow64FsRedirection inst…

### DIFF
--- a/al-khaser/Al-khaser.cpp
+++ b/al-khaser/Al-khaser.cpp
@@ -30,13 +30,14 @@ int main(void)
 	/* Display general informations */
 	_tprintf(_T("[al-khaser version 0.79]"));
 
-	if (IsWoW64())
-		_tprintf(_T("Process is running under WOW64\n\n"));
-
 	print_category(TEXT("Initialisation"));
 	API::Init();
 	print_os();
 	API::PrintAvailabilityReport();
+
+	/* Are we running under WoW64 */
+	if (IsWoW64())
+		_tprintf(_T("Process is running under WOW64\n\n"));
 
 	if (ENABLE_DEBUG_CHECKS) PageExceptionInitialEnum();
 

--- a/al-khaser/AntiVM/VMWare.cpp
+++ b/al-khaser/AntiVM/VMWare.cpp
@@ -63,27 +63,33 @@ VOID vmware_files()
 {
 	/* Array of strings of blacklisted paths */
 	const TCHAR* szPaths[] = {
-		_T("SysNative\\drivers\\vmnet.sys"),
-		_T("SysNative\\drivers\\vmmouse.sys"),
-		_T("SysNative\\drivers\\vmusb.sys"),
-		_T("SysNative\\drivers\\vm3dmp.sys"),
-		_T("SysNative\\drivers\\vmci.sys"),
-		_T("SysNative\\drivers\\vmhgfs.sys"),
-		_T("SysNative\\drivers\\vmmemctl.sys"),
-		_T("SysNative\\drivers\\vmx86.sys"),
-		_T("SysNative\\drivers\\vmrawdsk.sys"),
-		_T("SysNative\\drivers\\vmusbmouse.sys"),
-		_T("SysNative\\drivers\\vmkdb.sys"),
-		_T("SysNative\\drivers\\vmnetuserif.sys"),
-		_T("SysNative\\drivers\\vmnetadapter.sys"),
+		_T("System32\\drivers\\vmnet.sys"),
+		_T("System32\\drivers\\vmmouse.sys"),
+		_T("System32\\drivers\\vmusb.sys"),
+		_T("System32\\drivers\\vm3dmp.sys"),
+		_T("System32\\drivers\\vmci.sys"),
+		_T("System32\\drivers\\vmhgfs.sys"),
+		_T("System32\\drivers\\vmmemctl.sys"),
+		_T("System32\\drivers\\vmx86.sys"),
+		_T("System32\\drivers\\vmrawdsk.sys"),
+		_T("System32\\drivers\\vmusbmouse.sys"),
+		_T("System32\\drivers\\vmkdb.sys"),
+		_T("System32\\drivers\\vmnetuserif.sys"),
+		_T("System32\\drivers\\vmnetadapter.sys"),
 	};
 
 	/* Getting Windows Directory */
 	WORD dwlength = sizeof(szPaths) / sizeof(szPaths[0]);
 	TCHAR szWinDir[MAX_PATH] = _T("");
 	TCHAR szPath[MAX_PATH] = _T("");
+	PVOID OldValue = NULL;
+
 	GetWindowsDirectory(szWinDir, MAX_PATH);
 
+	if (IsWoW64()) {
+		Wow64DisableWow64FsRedirection(&OldValue);
+	}
+	
 	/* Check one by one */
 	for (int i = 0; i < dwlength; i++)
 	{
@@ -95,6 +101,11 @@ VOID vmware_files()
 		else
 			print_results(FALSE, msg);
 	}
+
+	if (IsWoW64()) {
+		Wow64RevertWow64FsRedirection(&OldValue);
+	}
+	
 }
 
 /*

--- a/al-khaser/AntiVM/VirtualBox.cpp
+++ b/al-khaser/AntiVM/VirtualBox.cpp
@@ -69,30 +69,36 @@ VOID vbox_files()
 {
 	/* Array of strings of blacklisted paths */
 	const TCHAR* szPaths[] = {
-		_T("SysNative\\drivers\\VBoxMouse.sys"),
-		_T("SysNative\\drivers\\VBoxGuest.sys"),
-		_T("SysNative\\drivers\\VBoxSF.sys"),
-		_T("SysNative\\drivers\\VBoxVideo.sys"),
-		_T("SysNative\\vboxdisp.dll"),
-		_T("SysNative\\vboxhook.dll"),
-		_T("SysNative\\vboxmrxnp.dll"),
-		_T("SysNative\\vboxogl.dll"),
-		_T("SysNative\\vboxoglarrayspu.dll"),
-		_T("SysNative\\vboxoglcrutil.dll"),
-		_T("SysNative\\vboxoglerrorspu.dll"),
-		_T("SysNative\\vboxoglfeedbackspu.dll"),
-		_T("SysNative\\vboxoglpackspu.dll"),
-		_T("SysNative\\vboxoglpassthroughspu.dll"),
-		_T("SysNative\\vboxservice.exe"),
-		_T("SysNative\\vboxtray.exe"),
-		_T("SysNative\\VBoxControl.exe"),
+		_T("System32\\drivers\\VBoxMouse.sys"),
+		_T("System32\\drivers\\VBoxGuest.sys"),
+		_T("System32\\drivers\\VBoxSF.sys"),
+		_T("System32\\drivers\\VBoxVideo.sys"),
+		_T("System32\\vboxdisp.dll"),
+		_T("System32\\vboxhook.dll"),
+		_T("System32\\vboxmrxnp.dll"),
+		_T("System32\\vboxogl.dll"),
+		_T("System32\\vboxoglarrayspu.dll"),
+		_T("System32\\vboxoglcrutil.dll"),
+		_T("System32\\vboxoglerrorspu.dll"),
+		_T("System32\\vboxoglfeedbackspu.dll"),
+		_T("System32\\vboxoglpackspu.dll"),
+		_T("System32\\vboxoglpassthroughspu.dll"),
+		_T("System32\\vboxservice.exe"),
+		_T("System32\\vboxtray.exe"),
+		_T("System32\\VBoxControl.exe"),
 	};
 
 	/* Getting Windows Directory */
 	WORD dwlength = sizeof(szPaths) / sizeof(szPaths[0]);
 	TCHAR szWinDir[MAX_PATH] = _T("");
 	TCHAR szPath[MAX_PATH] = _T("");
+	PVOID OldValue = NULL;
+
 	GetWindowsDirectory(szWinDir, MAX_PATH);
+
+	if (IsWoW64()) {
+		Wow64DisableWow64FsRedirection(&OldValue);
+	}
 
 	/* Check one by one */
 	for (int i = 0; i < dwlength; i++)
@@ -104,6 +110,10 @@ VOID vbox_files()
 			print_results(TRUE, msg);
 		else
 			print_results(FALSE, msg);
+	}
+
+	if (IsWoW64()) {
+		Wow64RevertWow64FsRedirection(&OldValue);
 	}
 }
 


### PR DESCRIPTION
Move the code below after API initialization otherwise IsWoW64() will miss the api being resolved.

```
/* Are we running under WoW64 */
if (IsWoW64())
    _tprintf(_T("Process is running under WOW64\n\n"));
```

Plus, fix the previous commit to disable and revert fs redirection while proving for files under system32/ dir.