### PR TITLE
Fix #189 - Add known hostname / username checks from malware

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Please, if you encounter any of the anti-analysis tricks which you have seen in 
 - Color of background pixel (todo)
 - Keyboard layout (Win32/Banload) (todo)
 - Genuine Windows installation.
+- Known Sandbox hostnames and usernames
 
 
 ### Anti-Virtualization / Full-System Emulation

--- a/al-khaser/Al-khaser.cpp
+++ b/al-khaser/Al-khaser.cpp
@@ -108,6 +108,9 @@ int main(void)
 		print_category(TEXT("Generic Sandboxe/VM Detection"));
 		loaded_dlls();
 		known_file_names();
+		known_usernames();
+		known_hostnames();
+		other_known_sandbox_environment_checks();
 		exec_check(&NumberOfProcessors, TEXT("Checking Number of processors in machine "));
 		exec_check(&idt_trick, TEXT("Checking Interupt Descriptor Table location "));
 		exec_check(&ldt_trick, TEXT("Checking Local Descriptor Table location "));

--- a/al-khaser/AntiVM/Generic.cpp
+++ b/al-khaser/AntiVM/Generic.cpp
@@ -96,7 +96,266 @@ VOID known_file_names() {
 	else 
 		print_results(FALSE, msg);
 }
+
+static TCHAR * get_username() {
+	TCHAR *username;
+	DWORD nSize = (UNLEN + 1);
+
+	username = (TCHAR *) malloc(nSize * sizeof(TCHAR));
+	if (!username) {
+		return NULL;
+	}
+	if (0 == GetUserName(username, &nSize)) {
+		free(username);
+		return NULL;
+	}
+	return username;
+}
+
+/*
+Check for usernames associated with sandboxes
+*/
+VOID known_usernames() {
+
+	/* Array of strings of usernames seen in sandboxes */
+	CONST TCHAR* szUsernames[] = {
+		/* Checked for by Gootkit
+		 * https://www.sentinelone.com/blog/gootkit-banking-trojan-deep-dive-anti-analysis-features/ */
+		_T("CurrentUser"),
+		_T("Sandbox"),
+
+		/* Checked for by ostap
+		 * https://www.bromium.com/deobfuscating-ostap-trickbots-javascript-downloader/ */
+		_T("Emily"),
+		_T("HAPUBWS"),
+		_T("Hong Lee"),
+		_T("IT-ADMIN"),
+		_T("Johnson"),
+		_T("Miller"),
+		_T("milozs"),
+		_T("Peter Wilson"),
+		_T("timmy"),
+		_T("user"),
+
+		/* Checked for by Betabot (not including ones from above)
+		 * https://www.bromium.com/deobfuscating-ostap-trickbots-javascript-downloader/ */
+		_T("sand box"),
+		_T("malware"),
+		_T("maltest"),
+		_T("test user"),
+
+		/* Checked for by Satan (not including ones from above)
+		 * https://cofense.com/satan/ */
+		_T("virus"),
+
+		/* Checked for by Emotet (not including ones from above)
+		 * https://blog.trendmicro.com/trendlabs-security-intelligence/new-emotet-hijacks-windows-api-evades-sandbox-analysis/ */
+		_T("John Doe"), /* VirusTotal Cuckoofork Sandbox */
+	};
+	TCHAR *username;
+
+	if (NULL == (username = get_username())) {
+		return;
+	}
+
+	TCHAR msg[256];
+	WORD dwlength = sizeof(szUsernames) / sizeof(szUsernames[0]);
+	for (int i = 0; i < dwlength; i++) {
+
+		_stprintf_s(msg, sizeof(msg) / sizeof(msg[0]), _T("Checking if username matches : %s "), szUsernames[i]);
+
+		/* Do a case-insensitive search for all entries in szHostnames */
+		BOOL matched = FALSE;
+		if (0 == _tcsicmp(szUsernames[i], username)) {
+			matched = TRUE;
+		}
+
+		print_results(matched, msg);
+	}
+
+	free(username);
+}
+
+static TCHAR * get_netbios_hostname() {
+	TCHAR *hostname;
+	DWORD nSize = (MAX_COMPUTERNAME_LENGTH + 1);
+
+	hostname = (TCHAR *) malloc(nSize * sizeof(TCHAR));
+	if (!hostname) {
+		return NULL;
+	}
+	if (0 == GetComputerName(hostname, &nSize)) {
+		free(hostname);
+		return NULL;
+	}
+	return hostname;
+}
+
+static TCHAR * get_dns_hostname() {
+	TCHAR *hostname;
+	DWORD nSize = 0;
+
+	GetComputerNameEx(ComputerNameDnsHostname, NULL, &nSize);
+	hostname = (TCHAR *) malloc((nSize + 1) * sizeof(TCHAR));
+	if (!hostname) {
+		return NULL;
+	}
+	if (0 == GetComputerNameEx(ComputerNameDnsHostname, hostname, &nSize)) {
+		free(hostname);
+		return NULL;
+	}
+	return hostname;
+}
+
+/*
+Check for hostnames associated with sandboxes
+*/
+VOID known_hostnames() {
+
+	/* Array of strings of hostnames seen in sandboxes */
+	CONST TCHAR* szHostnames[] = {
+		/* Checked for by Gootkit
+		 * https://www.sentinelone.com/blog/gootkit-banking-trojan-deep-dive-anti-analysis-features/ */
+		_T("SANDBOX"),
+		_T("7SILVIA"),
+
+		/* Checked for by ostap
+		 * https://www.bromium.com/deobfuscating-ostap-trickbots-javascript-downloader/ */
+		_T("HANSPETER-PC"),
+		_T("JOHN-PC"),
+		_T("MUELLER-PC"),
+		_T("WIN7-TRAPS"),
+
+		/* Checked for by Shifu (not including ones from above)
+		 * https://www.mcafee.com/blogs/other-blogs/mcafee-labs/japanese-banking-trojan-shifu-combines-malware-tools */
+		_T("FORTINET"),
+
+		/* Checked for by Emotet (not including ones from above)
+		 * https://blog.trendmicro.com/trendlabs-security-intelligence/new-emotet-hijacks-windows-api-evades-sandbox-analysis/ */
+		_T("TEQUILABOOMBOOM"), /* VirusTotal Cuckoofork Sandbox */
+	};
+	TCHAR *NetBIOSHostName;
+	TCHAR *DNSHostName;
+
+	if (NULL == (NetBIOSHostName = get_netbios_hostname())) {
+		return;
+	}
+
+	if (NULL == (DNSHostName = get_dns_hostname())) {
+		free(NetBIOSHostName);
+		return;
+	}
+
+	TCHAR msg[256];
+	WORD dwlength = sizeof(szHostnames) / sizeof(szHostnames[0]);
+	for (int i = 0; i < dwlength; i++) {
+
+		_stprintf_s(msg, sizeof(msg) / sizeof(msg[0]), _T("Checking if hostname matches : %s "), szHostnames[i]);
+
+		/* Do a case-insensitive search for all entries in szHostnames */
+		BOOL matched = FALSE;
+		if (0 == _tcsicmp(szHostnames[i], NetBIOSHostName)) {
+			matched = TRUE;
+		}
+		else if (0 == _tcsicmp(szHostnames[i], DNSHostName)) {
+			matched = TRUE;
+		}
+
+		print_results(matched, msg);
+	}
+
+	free(NetBIOSHostName);
+	free(DNSHostName);
+}
+
+static BOOL check_file_exists(TCHAR *path) {
+	HANDLE hFile;
 	
+	hFile = CreateFile(path, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+
+	if (hFile == INVALID_HANDLE_VALUE) {
+		return FALSE;
+	}
+	else {
+		CloseHandle(hFile);
+		return TRUE;
+	}
+}
+
+/*
+Check for a combination of environmental conditions, replicating what malware
+could/has used to detect that it's running in a sandbox. */
+VOID other_known_sandbox_environment_checks() {
+	TCHAR *NetBIOSHostName;
+	TCHAR *DNSHostName;
+	TCHAR *username;
+	BOOL matched;
+
+	if (NULL == (username = get_username())) {
+		return;
+	}
+	if (NULL == (NetBIOSHostName = get_netbios_hostname())) {
+		free(username);
+		return;
+	}
+
+	if (NULL == (DNSHostName = get_dns_hostname())) {
+		free(username);
+		free(NetBIOSHostName);
+		return;
+	}
+	/* From Emotet
+	 * https://blog.trendmicro.com/trendlabs-security-intelligence/new-emotet-hijacks-windows-api-evades-sandbox-analysis/ */
+
+	matched = FALSE;
+	if ((0 == StrCmp(username, _T("Wilber"))) &&
+		((0 == StrCmpNI(NetBIOSHostName, _T("SC"), 2)) ||
+	     (0 == StrCmpNI(NetBIOSHostName, _T("SW"), 2)))) {
+		matched = TRUE;
+	}
+	print_results(matched, (TCHAR *)_T("Checking whether username is 'Wilber' and NetBIOS name starts with 'SC' or 'SW' "));
+
+	matched = FALSE;
+	if ((0 == StrCmp(username, _T("admin"))) && (0 == StrCmp(NetBIOSHostName, _T("SystemIT")))) {
+		matched = TRUE;
+	}
+	print_results(matched, (TCHAR *)_T("Checking whether username is 'admin' and NetBIOS name is 'SystemIT' "));
+
+	matched = FALSE;
+	if ((0 == StrCmp(username, _T("admin"))) && (0 == StrCmp(DNSHostName, _T("KLONE_X64-PC")))) {
+		matched = TRUE;
+	}
+	print_results(matched, (TCHAR *) _T("Checking whether username is 'admin' and DNS hostname is 'KLONE_X64-PC' "));
+
+	matched = FALSE;
+	if ((0 == StrCmp(username, _T("John"))) &&
+		(check_file_exists((TCHAR *)_T("C:\\take_screenshot.ps1"))) &&
+		(check_file_exists((TCHAR *)_T("C:\\loaddll.exe")))) {
+		matched = TRUE;
+	}
+	print_results(matched, (TCHAR *)_T("Checking whether username is 'John' and two sandbox files exist "));
+
+	matched = FALSE;
+	if ((check_file_exists((TCHAR *)_T("C:\\email.doc"))) &&
+		(check_file_exists((TCHAR *)_T("C:\\email.htm"))) &&
+		(check_file_exists((TCHAR *)_T("C:\\123\\email.doc"))) &&
+		(check_file_exists((TCHAR *)_T("C:\\123\\email.docx")))) {
+		matched = TRUE;
+	}
+	print_results(matched, (TCHAR *)_T("Checking whether four known sandbox 'email' file paths exist "));
+
+	matched = FALSE;
+	if ((check_file_exists((TCHAR *)_T("C:\\a\\foobar.bmp"))) &&
+		(check_file_exists((TCHAR *)_T("C:\\a\\foobar.doc"))) &&
+		(check_file_exists((TCHAR *)_T("C:\\a\\foobar.gif")))) {
+		matched = TRUE;
+	}
+	print_results(matched, (TCHAR *)_T("Checking whether three known sandbox 'foobar' files exist "));
+
+	free(username);
+	free(NetBIOSHostName);
+	free(DNSHostName);
+}
 
 /*
 Detect Hybrid Analysis with mac vendor

--- a/al-khaser/AntiVM/Generic.cpp
+++ b/al-khaser/AntiVM/Generic.cpp
@@ -130,8 +130,8 @@ VOID known_usernames() {
 		_T("HAPUBWS"),
 		_T("Hong Lee"),
 		_T("IT-ADMIN"),
-		_T("Johnson"),
-		_T("Miller"),
+		_T("Johnson"), /* Lastline Sandbox */
+		_T("Miller"), /* Lastline Sandbox */
 		_T("milozs"),
 		_T("Peter Wilson"),
 		_T("timmy"),
@@ -268,20 +268,6 @@ VOID known_hostnames() {
 	free(DNSHostName);
 }
 
-static BOOL check_file_exists(TCHAR *path) {
-	HANDLE hFile;
-	
-	hFile = CreateFile(path, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
-
-	if (hFile == INVALID_HANDLE_VALUE) {
-		return FALSE;
-	}
-	else {
-		CloseHandle(hFile);
-		return TRUE;
-	}
-}
-
 /*
 Check for a combination of environmental conditions, replicating what malware
 could/has used to detect that it's running in a sandbox. */
@@ -329,25 +315,25 @@ VOID other_known_sandbox_environment_checks() {
 
 	matched = FALSE;
 	if ((0 == StrCmp(username, _T("John"))) &&
-		(check_file_exists((TCHAR *)_T("C:\\take_screenshot.ps1"))) &&
-		(check_file_exists((TCHAR *)_T("C:\\loaddll.exe")))) {
+		(is_FileExists((TCHAR *)_T("C:\\take_screenshot.ps1"))) &&
+		(is_FileExists((TCHAR *)_T("C:\\loaddll.exe")))) {
 		matched = TRUE;
 	}
 	print_results(matched, (TCHAR *)_T("Checking whether username is 'John' and two sandbox files exist "));
 
 	matched = FALSE;
-	if ((check_file_exists((TCHAR *)_T("C:\\email.doc"))) &&
-		(check_file_exists((TCHAR *)_T("C:\\email.htm"))) &&
-		(check_file_exists((TCHAR *)_T("C:\\123\\email.doc"))) &&
-		(check_file_exists((TCHAR *)_T("C:\\123\\email.docx")))) {
+	if ((is_FileExists((TCHAR *)_T("C:\\email.doc"))) &&
+		(is_FileExists((TCHAR *)_T("C:\\email.htm"))) &&
+		(is_FileExists((TCHAR *)_T("C:\\123\\email.doc"))) &&
+		(is_FileExists((TCHAR *)_T("C:\\123\\email.docx")))) {
 		matched = TRUE;
 	}
 	print_results(matched, (TCHAR *)_T("Checking whether four known sandbox 'email' file paths exist "));
 
 	matched = FALSE;
-	if ((check_file_exists((TCHAR *)_T("C:\\a\\foobar.bmp"))) &&
-		(check_file_exists((TCHAR *)_T("C:\\a\\foobar.doc"))) &&
-		(check_file_exists((TCHAR *)_T("C:\\a\\foobar.gif")))) {
+	if ((is_FileExists((TCHAR *)_T("C:\\a\\foobar.bmp"))) &&
+		(is_FileExists((TCHAR *)_T("C:\\a\\foobar.doc"))) &&
+		(is_FileExists((TCHAR *)_T("C:\\a\\foobar.gif")))) {
 		matched = TRUE;
 	}
 	print_results(matched, (TCHAR *)_T("Checking whether three known sandbox 'foobar' files exist "));

--- a/al-khaser/AntiVM/Generic.h
+++ b/al-khaser/AntiVM/Generic.h
@@ -2,6 +2,9 @@
 
 VOID loaded_dlls();
 VOID known_file_names();
+VOID known_usernames();
+VOID known_hostnames();
+VOID other_known_sandbox_environment_checks();
 BOOL NumberOfProcessors();
 BOOL idt_trick();
 BOOL ldt_trick();


### PR DESCRIPTION
This implements all the checks from #189.  Let me know what you think - I'm happy to implement any suggested changes.

I'm participating in Hacktoberfest 2020, and figured this would be a good issue to tackle for that.  If you are OK with this PR would you mind adding a label to it called `hacktoberfest-accepted` so it will be counted? Thank you!

https://hacktoberfest.digitalocean.com/details#details