### PR TITLE
Improve parent process check to avoid false positives.

### DIFF
--- a/al-khaser/pch.h
+++ b/al-khaser/pch.h
@@ -15,6 +15,7 @@
 
 #include <string>
 #include <vector>
+#include <filesystem>
 
 #include <Windows.h>
 #include <winternl.h>


### PR DESCRIPTION
The previous method of checking if the process was launched by Explorer was very prone to false positives, since it would return a detection if you have Explorer process isolation enabled (i.e. one process per explorer window).

The new method finds the parent process ID and checks the main module path to see if it's an explorer.exe process. The full path is checked so as to avoid the trick of just renaming the parent process to explorer.exe somewhere else in the filesystem.

If the parent process filename or explorer path cannot be fetched for some reason, the check falls back to the old method. It also handles the situation where GetExplorerPIDbyShellWindow fails and returns zero.

@LordNoteworthy: Requesting review from you just to sanity-check my code and see if I missed anything.