### PR TITLE
Fix ScanForModules_MemoryWalk_Hidden and add new .NET structure scan.

### DIFF
--- a/al-khaser/Al-khaser.cpp
+++ b/al-khaser/Al-khaser.cpp
@@ -101,6 +101,7 @@ int main(void)
 		exec_check(&ScanForModules_LDR_Direct, TEXT("Enumerating the process LDR directly "));
 		exec_check(&ScanForModules_MemoryWalk_GMI, TEXT("Walking process memory with GetModuleInformation "));
 		exec_check(&ScanForModules_MemoryWalk_Hidden, TEXT("Walking process memory for hidden modules "));
+		exec_check(&ScanForModules_DotNetModuleStructures, TEXT("Walking process memory for .NET module structures "));
 	}
 
 	/* Generic sandbox detection */

--- a/al-khaser/AntiDebug/ScanForModules.h
+++ b/al-khaser/AntiDebug/ScanForModules.h
@@ -8,3 +8,4 @@ BOOL ScanForModules_LDR_Direct();
 BOOL ScanForModules_LdrEnumerateLoadedModules();
 BOOL ScanForModules_MemoryWalk_GMI();
 BOOL ScanForModules_MemoryWalk_Hidden();
+BOOL ScanForModules_DotNetModuleStructures();


### PR DESCRIPTION
The memory walk check was broken because it assumed that memory regions would be executable. It also started at the wrong address - AllocationBase is the start of the allocator region, whereas BaseAddress is the actual start of the region. This has now been fixed.

This commit also adds a new check, which scans for memory structures that the .NET runtime creates to track loaded modules. This should catch injected modules even if they're dynamically loaded from memory.

This fixes #234 and #237.