### PR TITLE
Update Al-khaser.cpp

### DIFF
--- a/al-khaser/Al-khaser.cpp
+++ b/al-khaser/Al-khaser.cpp
@@ -242,7 +242,7 @@ int main(void)
 	if (ENABLE_PARALLELS_CHECKS) {
 		print_category(TEXT("Paralles Detection"));
 		parallels_process();
-		exec_check(&parallels_check_mac, TEXT("Checking Mac Address start with 08:1C:42 "));
+		exec_check(&parallels_check_mac, TEXT("Checking Mac Address start with 00:1C:42 "));
 	}
 
 	if (ENABLE_HYPERV_CHECKS) {


### PR DESCRIPTION
In function `parallels_check_mac()`, the MAC address prefix is right: `\x00\x1C\x42`, but the description about the MAC address prefix of parallels desktop is not accurate, not `08:1C:42` but `00:1C:42`