### PR TITLE
Checking the virtual machine through the number of SMBIOS tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Please, if you encounter any of the anti-analysis tricks which you have seen in 
   - SMBIOS string checks (VirtualBox)
   - SMBIOS string checks (VMWare)
   - SMBIOS string checks (Qemu)
+  - SMBIOS number of tables (Qemu, VirtualBox)
   - ACPI string checks (VirtualBox)
   - ACPI string checks (VMWare)
   - ACPI string checks (Qemu)

--- a/al-khaser/Al-khaser.cpp
+++ b/al-khaser/Al-khaser.cpp
@@ -213,6 +213,7 @@ int main(int argc, char* argv[])
 		exec_check(&pirated_windows, TEXT("Checking if Windows is Genuine "));
 		exec_check(&registry_services_disk_enum, TEXT("Checking Services\\Disk\\Enum entries for VM strings "));
 		exec_check(&registry_disk_enum, TEXT("Checking Enum\\IDE and Enum\\SCSI entries for VM strings "));
+		exec_check(&number_SMBIOS_tables, TEXT("Checking SMBIOS tables  "));
 	}
 
 	/* VirtualBox Detection */

--- a/al-khaser/AntiVM/Generic.h
+++ b/al-khaser/AntiVM/Generic.h
@@ -49,3 +49,4 @@ BOOL cim_voltagesensor_wmi();
 BOOL pirated_windows();
 BOOL registry_services_disk_enum();
 BOOL registry_disk_enum();
+BOOL number_SMBIOS_tables();


### PR DESCRIPTION
Hello. By the number of SMBIOS tables you can detect VM. For example, Virtual box and Qemu have only 10 SMBIOS tables. On a real table machine there will be at least 100 SMBIOS tables.