### PR TITLE
Attach project binaries to releases for accessibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,7 @@
-name: Build Pull Request Artifacts
-on: [pull_request]
+name: Build Release Artifacts
+on:
+  release:
+    types: [published]
 jobs:
   build:
     runs-on: windows-2022
@@ -24,15 +26,9 @@ jobs:
 
     - name: Zip x64 Binaries
       run: 7z a -t7z -m0=lzma2 -mx=9 -mfb=64 -md=32m -mhe=on -p"yug69gG89T98HGUY8y" al-khaser_x64.7z al-khaser_x64.exe
-        
-    - name: Upload x86 Binaries
-      uses: actions/upload-artifact@v4
-      with:
-          name: x86
-          path: "al-khaser_x86.7z"
 
-    - name: Upload x64 Binaries
-      uses: actions/upload-artifact@v4
+    - name: Attach Binaries to release
+      uses: AButler/upload-release-assets@v3.0
       with:
-          name: x64
-          path: "al-khaser_x64.7z"
+        files: "al-khaser_x*.7z"
+        repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -27,9 +27,7 @@ It performs a bunch of common malware tricks with the goal of seeing if you stay
 
 ## Download
 
-~~You can download the latest release here: [x86](https://github.com/LordNoteworthy/al-khaser/blob/master/al-khaser_x86.exe?raw=true) | [x64](https://github.com/LordNoteworthy/al-khaser/blob/master/al-khaser_x64.exe?raw=true).~~
-
-**Sorry, binaries have been removed for now as they were triggering Google's Safe Browsing heuristics.**
+You can download built binaries (x86, x64) from this project's [releases page](https://github.com/LordNoteworthy/al-khaser/releases). The password for the 7zs can be found [here](https://github.com/LordNoteworthy/al-khaser/blob/master/.github/workflows/release.yml#L25).
 
 
 ## Possible uses

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,2 +1,0 @@
-image:
-- Visual Studio 2017


### PR DESCRIPTION
This PR serves to address some of the issues with accessing the compiled binaries for this project. By generating releases for this project and attaching binaries to them, it should work around workflow artifacts expiring and any issues with binaries in the repo itself.

Included changes:
- bump the version of the upload-artifact version to a supported one
- change the existing build action to only run on PR events. This includes PRs being opened, additional commits being added to the source branch, etc
- add a new workflow that supports a release workflow

This would require that after merges to master, a maintainer go generate a release for the project, and associated git tag. That will trigger this new workflow and upload the built binaries (unzipped) to the release.

I've tested this on my fork:
- [building artifacts](https://github.com/holysoles/al-khaser/actions/runs/10975967979) upon [a PR request](https://github.com/holysoles/al-khaser/pull/2) being opened
  - [also ran a workflow for a subsequent commit](https://github.com/holysoles/al-khaser/actions/runs/10976020722)
- [building and attaching artifacts](https://github.com/holysoles/al-khaser/actions/runs/10975995792) for [a manually generated release](https://github.com/holysoles/al-khaser/releases/tag/v1.0.0)